### PR TITLE
Add example package showing direct use of PackageVariant

### DIFF
--- a/free5gc-smf-org-example/Kptfile
+++ b/free5gc-smf-org-example/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: free5gc-smf-org-example
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: Example package showing how a PackageVariant can be used to do systematic updates to a vendor package, creating an organizational package.

--- a/free5gc-smf-org-example/README.md
+++ b/free5gc-smf-org-example/README.md
@@ -1,0 +1,9 @@
+# free5gc-smf-org-example
+
+## Description
+Example package showing how a PackageVariant can be used to do systematic
+updates to a vendor package, creating an organizational package.
+
+When deployed to the Nephio management cluster, this package will create a
+variant of the free5gc SMF package, customized according to the conventions of
+the example.com company.

--- a/free5gc-smf-org-example/package-context.yaml
+++ b/free5gc-smf-org-example/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: example

--- a/free5gc-smf-org-example/packagevariant.yaml
+++ b/free5gc-smf-org-example/packagevariant.yaml
@@ -1,0 +1,20 @@
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: PackageVariant
+metadata:
+  name: free5g-smf-regional
+spec:
+  upstream:
+    repo: free5gc-packages
+    package: pkg-example-smf-bp
+    revision: v1
+  downstream:
+    repo: org-nf-catalog
+    package: free5gc-smf
+  labels:
+    'example.com/vendor': free5gc
+    'example.com/package-content': network-function
+    'example.com/nf-type': smf
+    'example.com/contact': "nf-platform-team@example.com"
+  packageContext:
+    data:
+      contact-email: "nf-platform-team@example.com"


### PR DESCRIPTION
This package will be used by the UI team to develop and test the PackageVariant viewer code.

It also serves as an example of one use of PackageVariant, directly, rather than via PackageVariantSet.