### PR TITLE
split kind cluster in template/real cluster

### DIFF
--- a/cluster-capi-kind-docker-templates/Kptfile
+++ b/cluster-capi-kind-docker-templates/Kptfile
@@ -5,4 +5,4 @@ metadata:
   annotations:
     config.kubernetes.io/local-config: "true"
 info:
-  description: This package provides a blueprint for deploying a capi cluster using the capi kind docker templates
+  description: This package provides the templates and classes for docker kind capi clusters

--- a/cluster-capi-kind-docker-templates/README.md
+++ b/cluster-capi-kind-docker-templates/README.md
@@ -1,0 +1,9 @@
+# cluster
+
+## Description
+
+This package provides the templates and classes for docker kind capi clusters
+
+The package has some host dependencies:
+- /opt/cni/bin for accessing the cni(s)
+- /var/run/docker.sock for the docker socket

--- a/cluster-capi-kind-docker-templates/cluster_class.yaml
+++ b/cluster-capi-kind-docker-templates/cluster_class.yaml
@@ -1,7 +1,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
-  name: nephio
+  name: docker
   namespace: default
 spec:
   controlPlane:
@@ -9,16 +9,16 @@ spec:
       ref:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
-        name: nephio-control-plane
+        name: docker-control-plane
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
-      name: nephio-control-plane
+      name: docker-control-plane
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DockerClusterTemplate
-      name: nephio-cluster
+      name: docker-cluster
   patches:
   - definitions:
     - jsonPatches:
@@ -64,7 +64,7 @@ spec:
         matchResources:
           machineDeploymentClass:
             names:
-            - default-worker
+            - docker-default-worker
     description: |
       Sets the cgroupDriver to cgroupfs if a Kubernetes version < v1.24 is referenced.
       This is required because kind and the node images do not support the default
@@ -113,7 +113,7 @@ spec:
         matchResources:
           machineDeploymentClass:
             names:
-            - default-worker
+            - docker-default-worker
     - jsonPatches:
       - op: add
         path: /spec/template/spec/customImage
@@ -126,7 +126,7 @@ spec:
         matchResources:
           controlPlane: true
     description: Sets the container image that is used for running dockerMachines
-      for the controlPlane and default-worker machineDeployments.
+      for the controlPlane and docker-default-worker machineDeployments.
     name: customImage
   - definitions:
     - jsonPatches:
@@ -228,15 +228,15 @@ spec:
         type: object
   workers:
     machineDeployments:
-    - class: default-worker
+    - class: docker-default-worker
       template:
         bootstrap:
           ref:
             apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
             kind: KubeadmConfigTemplate
-            name: nephio-default-worker-bootstraptemplate
+            name: docker-default-worker-bootstraptemplate
         infrastructure:
           ref:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
             kind: DockerMachineTemplate
-            name: nephio-default-worker-machinetemplate
+            name: docker-default-worker-machinetemplate

--- a/cluster-capi-kind-docker-templates/docker_cluster_template.yaml
+++ b/cluster-capi-kind-docker-templates/docker_cluster_template.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerClusterTemplate
 metadata:
-  name: nephio-cluster
+  name: docker-cluster
   namespace: default
 spec:
   template:

--- a/cluster-capi-kind-docker-templates/docker_machine_template_control_plane.yaml
+++ b/cluster-capi-kind-docker-templates/docker_machine_template_control_plane.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
-  name: nephio-default-worker-machinetemplate
+  name: docker-control-plane
   namespace: default
 spec:
   template:

--- a/cluster-capi-kind-docker-templates/docker_machine_template_worker.yaml
+++ b/cluster-capi-kind-docker-templates/docker_machine_template_worker.yaml
@@ -1,7 +1,7 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
-  name: nephio-control-plane
+  name: docker-default-worker-machinetemplate
   namespace: default
 spec:
   template:

--- a/cluster-capi-kind-docker-templates/kubeadm_config_template.yaml
+++ b/cluster-capi-kind-docker-templates/kubeadm_config_template.yaml
@@ -1,7 +1,7 @@
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: nephio-default-worker-bootstraptemplate
+  name: docker-default-worker-bootstraptemplate
   namespace: default
 spec:
   template:

--- a/cluster-capi-kind-docker-templates/kubeadm_controlplane_template.yaml
+++ b/cluster-capi-kind-docker-templates/kubeadm_controlplane_template.yaml
@@ -1,7 +1,7 @@
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlaneTemplate
 metadata:
-  name: nephio-control-plane
+  name: docker-control-plane
   namespace: default
 spec:
   template:

--- a/cluster-capi-kind-docker-templates/package-context.yaml
+++ b/cluster-capi-kind-docker-templates/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: example

--- a/cluster-capi-kind/README.md
+++ b/cluster-capi-kind/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This package provides a blueprint manifest to deploy a kind cluster using cluster api
+This package provides a blueprint for deploying a capi cluster using the capi kind docker templates
 
 The package contains some defaults but can be changed through the kpt pipeline
 - pod cidrBlocks: 192.168.0.0/16
@@ -10,7 +10,3 @@ The package contains some defaults but can be changed through the kpt pipeline
 - service domain: cluster.local
 - kubernetes version: v1.26.3
 - workers: 3
-
-The package has some host dependencies:
-- /opt/cni/bin for accessing the cni(s)
-- /var/run/docker.sock for the docker socket

--- a/cluster-capi-kind/cluster.yaml
+++ b/cluster-capi-kind/cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: nephio
+  name: workload
   namespace: default
 spec:
   clusterNetwork:
@@ -13,7 +13,7 @@ spec:
       cidrBlocks:
       - 10.128.0.0/12
   topology:
-    class: nephio
+    class: docker
     controlPlane:
       metadata: {}
       replicas: 1
@@ -33,6 +33,6 @@ spec:
     version: v1.26.3
     workers:
       machineDeployments:
-      - class: default-worker
+      - class: docker-default-worker
         name: md-0
         replicas: 3

--- a/cluster-capi/cluster-api-control-plane.yaml
+++ b/cluster-capi/cluster-api-control-plane.yaml
@@ -4293,7 +4293,7 @@ spec:
       - args:
         - --leader-elect
         - --metrics-bind-addr=localhost:8080
-        - --feature-gates=ClusterTopology=false,KubeadmBootstrapFormatIgnition=true
+        - --feature-gates=ClusterTopology=true,KubeadmBootstrapFormatIgnition=true
         command:
         - /manager
         image: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v1.1.5

--- a/cluster-capi/resourcegroup.yaml
+++ b/cluster-capi/resourcegroup.yaml
@@ -1,7 +1,0 @@
-apiVersion: kpt.dev/v1alpha1
-kind: ResourceGroup
-metadata:
-  name: inventory-92357326
-  namespace: default
-  labels:
-    cli-utils.sigs.k8s.io/inventory-id: 9f9580361445605cfe003a2d80b01fa41fe3ecd1-1683816273718484000


### PR DESCRIPTION
this PR splits the kind cluster in a template package and a cluster package which consumes the templates.
this PR fixes also a topologyFlag which was not set to true.