### PR TITLE
Add Nephio install packages

### DIFF
--- a/nephio-r1-base/Kptfile
+++ b/nephio-r1-base/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: nephio-r1-base
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: Base packages for the Nephio R1 Management Cluster

--- a/nephio-r1-base/README.md
+++ b/nephio-r1-base/README.md
@@ -1,0 +1,21 @@
+# nephio-r1-base
+
+## Description
+Base packages for the Nephio R1 Management Cluster
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] nephio-r1-base`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree nephio-r1-base`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init nephio-r1-base
+kpt live apply nephio-r1-base --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/nephio-r1-base/configsync/Kptfile
+++ b/nephio-r1-base/configsync/Kptfile
@@ -1,0 +1,23 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: configsync
+  annotations:
+    config.kubernetes.io/local-config: "true"
+upstream:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /configsync
+    ref: configsync/v1
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /configsync
+    ref: configsync/v1
+    commit: db1ce6c1a207991fafbb65e996e1130763759e20
+info:
+  site: https://nephio.org
+  description: Package for configSync.

--- a/nephio-r1-base/configsync/README.md
+++ b/nephio-r1-base/configsync/README.md
@@ -1,0 +1,4 @@
+# nephio-configsync
+
+## Description
+Package for the ConfigSync.

--- a/nephio-r1-base/configsync/config-management-operator.yaml
+++ b/nephio-r1-base/configsync/config-management-operator.yaml
@@ -1,0 +1,373 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /configmanagements.configmanagement.gke.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|configmanagements.configmanagement.gke.io'
+  creationTimestamp: null
+  name: configmanagements.configmanagement.gke.io
+spec:
+  group: configmanagement.gke.io
+  names:
+    kind: ConfigManagement
+    listKind: ConfigManagementList
+    plural: configmanagements
+    singular: configmanagement
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: ConfigManagement is the Schema for the ConfigManagement API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            properties:
+              name:
+                pattern: config-management
+                type: string
+            type: object
+          spec:
+            description: ConfigManagementSpec defines the desired state of ConfigManagement.
+            properties:
+              ConfigSyncDisableFSWatcher:
+                description: ConfigSyncDisableFSWatcher provides the ability to disable the fs-watcher process.  This field is intentionally left hidden/undocumented since it is only meant to be used by customers who have very large repositories. Optional.
+                type: boolean
+              ConfigSyncLogLevel:
+                description: ConfigSyncLogLevel overrides the logging verbosity for all ConfigSync pods. This field is intentionally left hidden/undocumented since it is really only used to gather extra logs for support cases.
+                type: integer
+              binauthz:
+                description: BinAuthz enables Binary Authorization as recognized by the "binauthz.configmanagement.gke.io" label set to "true".
+                properties:
+                  enabled:
+                    description: 'Enable or disable BinAuthz.  Default: false.'
+                    type: boolean
+                  policyRef:
+                    description: PolicyRef is a reference to the BinAuthz policy which will be evaluated. Required if BinAuthz is enabled.
+                    properties:
+                      gkeCluster:
+                        description: BinAuthz policy associated with this GKE-on-GCP cluster.
+                        properties:
+                          location:
+                            description: Location of this cluster
+                            type: string
+                          name:
+                            description: The name of this cluster according to GKE. This is not necessarily the same as the hub membership name.
+                            type: string
+                          project:
+                            description: The name of the GCP project containing this cluster
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              channel:
+                description: 'Channel specifies a channel that can be used to resolve a specific addon, eg: stable It will be ignored if Version is specified'
+                type: string
+              clusterName:
+                description: ClusterName, if defined, sets the name for this cluster.  If unset, the cluster is considered to be unnamed, and cannot use ClusterSelectors.
+                type: string
+              configConnector:
+                description: 'Deprecated: Does nothing.  ConfigConnector can no longer be enabled/disabled with the ConfigManagement resource; the software is available as a standalone: https://cloud.google.com/config-connector'
+                properties:
+                  enabled:
+                    description: 'Enable or disable the Config Connector.  Default: false.'
+                    type: boolean
+                type: object
+              enableLegacyFields:
+                description: EnableLegacyFields instructs the operator to use spec.git for generating a RootSync resource in MultiRepo mode. Note that this should only be set to true if spec.enableMultiRepo is set to true.
+                type: boolean
+              enableMultiRepo:
+                description: EnableMultiRepo instructs the operator to enable Multi Repo mode for Config Sync.
+                type: boolean
+              git:
+                description: Git contains configuration specific to importing policies from a Git repo.
+                properties:
+                  gcpServiceAccountEmail:
+                    description: 'GCPServiceAccountEmail specifies the GCP service account used to annotate the Config Sync Kubernetes Service Account. Note: The field is used when secretType: gcpServiceAccount.'
+                    type: string
+                  policyDir:
+                    description: 'PolicyDir is the absolute path of the directory that contains the local policy.  Default: the root directory of the repo.'
+                    type: string
+                  proxy:
+                    description: Proxy is a struct that contains options for configuring access to the Git repo via a proxy. Only has an effect when secretType is one of ("cookiefile", "none").  Optional.
+                    properties:
+                      httpProxy:
+                        description: HTTPProxy defines a HTTP_PROXY env variable used to access the Git repo.  If both HTTPProxy and HTTPSProxy are specified, HTTPProxy will be ignored. Optional.
+                        type: string
+                      httpsProxy:
+                        description: HTTPSProxy defines a HTTPS_PROXY env variable used to access the Git repo.  If both HTTPProxy and HTTPSProxy are specified, HTTPProxy will be ignored. Optional.
+                        type: string
+                    type: object
+                  secretType:
+                    description: SecretType is the type of secret configured for access to the Git repo. Must be one of ssh, cookiefile, gcenode, token, gcpserviceaccount or none. Required. The validation of this is case-sensitive.
+                    pattern: ^(ssh|cookiefile|gcenode|gcpserviceaccount|token|none)$
+                    type: string
+                  syncBranch:
+                    description: 'SyncBranch is the branch to sync from.  Default: "master".'
+                    type: string
+                  syncRepo:
+                    pattern: ^(((https?|git|ssh):\/\/)|git@)
+                    type: string
+                  syncRev:
+                    description: 'SyncRev is the git revision (tag or hash) to check out. Default: HEAD.'
+                    type: string
+                  syncWait:
+                    description: 'SyncWaitSeconds is the time duration in seconds between consecutive syncs.  Default: 15 seconds. Note that SyncWaitSecs is not a time.Duration on purpose. This provides a reminder to developers that customers specify this value using using integers like "3" in their ConfigManagement YAML. However, time.Duration is at a nanosecond granularity, and it''s easy to introduce a bug where it looks like the code is dealing with seconds but its actually nanoseconds (or vice versa).'
+                    type: integer
+                type: object
+              hierarchyController:
+                description: Hierarchy Controller enables HierarchyController components as recognized by the "hierarchycontroller.configmanagement.gke.io" label set to "true".
+                properties:
+                  enableHierarchicalResourceQuota:
+                    description: 'HierarchicalResourceQuota enforces resource quota in a hierarchical fashion: a resource quota set for one namespace provides constraints that limit aggregate resource consumption for that namespace and all its descendants. Disabling this will not delete user created hrq CRs, but will delete all the intermediate resources created by HRQ (specifically the resource quota singletons), which are labeled with hierarchycontroller.configmanagement.gke.io/hrq for easier cleanup.'
+                    type: boolean
+                  enablePodTreeLabels:
+                    description: PodTreeLabels copies the tree labels from namespaces to pods, allowing any system that uses pod logs (such as Stackdriver logging) to inspect the hierarchy.
+                    type: boolean
+                  enabled:
+                    description: 'Enable or disable the Hierarchy Controller.  Default: false.'
+                    type: boolean
+                type: object
+              importer:
+                description: Importer allows one to override the existing resource requirements for the importer pod
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              patches:
+                items:
+                  type: object
+                type: array
+                x-kubernetes-preserve-unknown-fields: true
+              policyController:
+                description: Policy Controller enables PolicyController components as recognized by the "gatekeeper.sh/manifest" label set to "true".
+                properties:
+                  auditIntervalSeconds:
+                    description: AuditIntervalSeconds. The number of seconds between audit runs. Defaults to 60 seconds. To disable audit, set this to 0.
+                    format: int64
+                    type: integer
+                  enabled:
+                    description: 'Enable or disable the Policy Controller.  Default: false.'
+                    type: boolean
+                  exemptableNamespaces:
+                    description: ExemptableNamespaces. The namespaces in this list are able to have the admission.gatekeeper.sh/ignore label set. When the label is set, Policy Controller will not be called for that namespace or any resources contained in it. `gatekeeper-system` is always exempted.
+                    items:
+                      type: string
+                    type: array
+                  logDeniesEnabled:
+                    description: 'LogDeniesEnabled.  If true, Policy Controller will log all denies and dryrun failures.  No effect unless policyController is enabled.  Default: false.'
+                    type: boolean
+                  monitoring:
+                    description: Monitoring specifies the configuration of monitoring.
+                    properties:
+                      backends:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  mutation:
+                    description: Mutation specifies the configuration of mutation. This is a preview feature and may change before becoming generally available.
+                    properties:
+                      enabled:
+                        description: 'Enable or disable mutation in policy controller. If true, mutation CRDs, webhook and controller will be deployed to the cluster. Default: false.'
+                        type: boolean
+                    type: object
+                  referentialRulesEnabled:
+                    description: 'ReferentialRulesEnabled.  If true, Policy Controller will allow `data.inventory` references in the contents of ConstraintTemplate Rego.  No effect unless policyController is enabled.  Default: false.'
+                    type: boolean
+                  templateLibraryInstalled:
+                    description: 'TemplateLibraryInstalled.  If true, a set of default ConstraintTemplates will be deployed to the cluster. ConstraintTemplates will not be deployed if this is explicitly set to false or if policyController is not enabled. Default: true.'
+                    type: boolean
+                type: object
+              preventDrift:
+                description: 'preventDrift, if set to `true`, enables the Config Sync admission webhook to prevent drifts. If set to `false`, disables the Config Sync admission webhook and does not prevent drifts. Default: false. Config Sync always corrects drifts no matter the value of preventDrift.'
+                type: boolean
+              sourceFormat:
+                description: "SourceFormat specifies how the repository is formatted. See documentation for specifics of what these options do. \n Must be one of hierarchy, unstructured. Optional. Set to hierarchy if not specified. \n The validation of this is case-sensitive."
+                pattern: ^(hierarchy|unstructured|)$
+                type: string
+              syncer:
+                description: Syncer allows one to override the existing resource requirements for the syncer pod
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              version:
+                description: Version specifies the exact addon version to be deployed, eg 1.2.3 It should not be specified if Channel is specified
+                type: string
+            type: object
+          status:
+            description: ConfigManagementStatus defines the observed state of ConfigManagement.
+            properties:
+              configManagementVersion:
+                description: ConfigManagementVersion is the semantic version number of the config management system enforced by the currently running config management operator.
+                type: string
+              errors:
+                items:
+                  type: string
+                type: array
+              healthy:
+                type: boolean
+              phase:
+                type: string
+            required:
+            - healthy
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /config-management-system
+  name: config-management-system
+  labels:
+    configmanagement.gke.io/system: "true"
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|config-management-system'
+---
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /config-management-monitoring
+  name: config-management-monitoring
+  labels:
+    configmanagement.gke.io/system: "true"
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|config-management-monitoring'
+---
+# The Nomos system creates RBAC rules, so it requires
+# full cluster-admin access. Thus, the operator needs
+# to be able to grant tha permission to the installed
+# Nomos components.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /config-management-operator
+  labels:
+    k8s-app: config-management-operator
+  name: config-management-operator
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|config-management-operator'
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /config-management-operator
+  labels:
+    k8s-app: config-management-operator
+  name: config-management-operator
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|config-management-operator'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: config-management-operator
+subjects:
+- kind: ServiceAccount
+  name: config-management-operator
+  namespace: config-management-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: # kpt-merge: config-management-system/config-management-operator
+  labels:
+    k8s-app: config-management-operator
+  name: config-management-operator
+  namespace: config-management-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|config-management-system|config-management-operator'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: config-management-system/config-management-operator
+  name: config-management-operator
+  namespace: config-management-system
+  labels:
+    k8s-app: config-management-operator
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|config-management-system|config-management-operator'
+spec:
+  strategy:
+    type: Recreate
+    # must be null due to 3-way merge, as
+    # rollingUpdate added to the resource by default by the APIServer
+    rollingUpdate: null
+  selector:
+    matchLabels:
+      k8s-app: config-management-operator
+      component: config-management-operator
+  template:
+    metadata:
+      labels:
+        k8s-app: config-management-operator
+        component: config-management-operator
+    spec:
+      containers:
+      - command:
+        - /manager
+        - --private-registry=
+        name: manager
+        image: gcr.io/config-management-release/config-management-operator:20220617195442-op
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        envFrom:
+        - configMapRef:
+            name: operator-environment-options
+            optional: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+      serviceAccount: config-management-operator
+      securityContext:
+        runAsUser: 1000
+        runAsNonRoot: true

--- a/nephio-r1-base/configsync/configsync.yaml
+++ b/nephio-r1-base/configsync/configsync.yaml
@@ -1,0 +1,9 @@
+apiVersion: configmanagement.gke.io/v1
+kind: ConfigManagement
+metadata: # kpt-merge: /config-management
+  name: config-management
+  annotations:
+    config.kubernetes.io/depends-on: apiextensions.k8s.io/CustomResourceDefinition/configmanagements.configmanagement.gke.io
+    internal.kpt.dev/upstream-identifier: 'configmanagement.gke.io|ConfigManagement|default|config-management'
+spec:
+  enableMultiRepo: true

--- a/nephio-r1-base/configsync/package-context.yaml
+++ b/nephio-r1-base/configsync/package-context.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: /kptfile.kpt.dev
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|kptfile.kpt.dev'
+data:
+  name: example

--- a/nephio-r1-base/configsync/rootsync-crd.yaml
+++ b/nephio-r1-base/configsync/rootsync-crd.yaml
@@ -1,0 +1,1372 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /rootsyncs.configsync.gke.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|rootsyncs.configsync.gke.io'
+  labels:
+    configmanagement.gke.io/arch: csmr
+    configmanagement.gke.io/system: "true"
+  name: rootsyncs.configsync.gke.io
+spec:
+  group: configsync.gke.io
+  names:
+    kind: RootSync
+    listKind: RootSyncList
+    plural: rootsyncs
+    singular: rootsync
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.rendering.commit
+      name: RenderingCommit
+      type: string
+    - jsonPath: .status.rendering.errorSummary.totalCount
+      name: RenderingErrorCount
+      type: integer
+    - jsonPath: .status.source.commit
+      name: SourceCommit
+      type: string
+    - jsonPath: .status.source.errorSummary.totalCount
+      name: SourceErrorCount
+      type: integer
+    - jsonPath: .status.sync.commit
+      name: SyncCommit
+      type: string
+    - jsonPath: .status.sync.errorSummary.totalCount
+      name: SyncErrorCount
+      type: integer
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RootSync is the Schema for the rootsyncs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RootSyncSpec defines the desired state of RootSync
+            properties:
+              git:
+                description: git contains configuration specific to importing resources from a Git repo.
+                properties:
+                  auth:
+                    description: auth is the type of secret configured for access to the Git repo. Must be one of ssh, cookiefile, gcenode, token, or none. The validation of this is case-sensitive. Required.
+                    enum:
+                    - ssh
+                    - cookiefile
+                    - gcenode
+                    - gcpserviceaccount
+                    - token
+                    - none
+                    type: string
+                  branch:
+                    description: 'branch is the git branch to checkout. Default: "master".'
+                    type: string
+                  dir:
+                    description: 'dir is the absolute path of the directory that contains the local resources.  Default: the root directory of the repo.'
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when spec.git.auth: gcpserviceaccount.'
+                    type: string
+                  noSSLVerify:
+                    description: 'noSSLVerify specifies whether to enable or disable the SSL certificate verification. Default: false. If noSSLVerify is set to true, it tells Git to skip the SSL certificate verification.'
+                    type: boolean
+                  period:
+                    description: 'period is the time duration between consecutive syncs. Default: 15s. Note to developers that customers specify this value using string (https://golang.org/pkg/time/#Duration.String) like "3s" in their Custom Resource YAML. However, time.Duration is at a nanosecond granularity, and it is easy to introduce a bug where it looks like the code is dealing with seconds but its actually nanoseconds (or vice versa).'
+                    type: string
+                  proxy:
+                    description: proxy specifies an HTTPS proxy for accessing the Git repo. Only has an effect when secretType is one of ("cookiefile", "none", "token"). When secretType is "cookiefile" or "token", if your HTTPS proxy URL contains sensitive information such as a username or password and you need to hide the sensitive information, you can leave this field empty and add the URL for the HTTPS proxy into the same Secret used for the Git credential via `kubectl create secret ... --from-literal=https_proxy=HTTPS_PROXY_URL`. Optional.
+                    type: string
+                  repo:
+                    description: repo is the git repository URL to sync from. Required.
+                    type: string
+                  revision:
+                    description: 'revision is the git revision (tag, ref or commit) to fetch. Default: "HEAD".'
+                    type: string
+                  secretRef:
+                    description: secretRef is the secret used to connect to the Git source of truth.
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                required:
+                - auth
+                - repo
+                type: object
+              helm:
+                description: helm contains configuration specific to importing resources from a Helm repo.
+                properties:
+                  auth:
+                    description: auth specifies the type to authenticate to the Helm repository. Must be one of secret, gcpserviceaccount, or none. The validation of this is case-sensitive. Required.
+                    enum:
+                    - none
+                    - gcpserviceaccount
+                    - token
+                    type: string
+                  chart:
+                    description: chart is a Helm chart name. Required.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when spec.helm.auth: gcpserviceaccount.'
+                    type: string
+                  includeCRDs:
+                    description: 'includeCRDs specifies if Helm template should also generate CustomResourceDefinitions. If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated. Default: false.'
+                    type: boolean
+                  namespace:
+                    description: namespace sets the target namespace for a release
+                    type: string
+                  period:
+                    description: 'period is the time duration between consecutive syncs. Default: 15s. Use string to specify this field value, like "30s", "5m". More details about valid inputs: https://pkg.go.dev/time#ParseDuration. Chart will not be re-synced if version is specified and it is not "latest"'
+                    type: string
+                  releaseName:
+                    description: releaseName is the name of the Helm release.
+                    type: string
+                  repo:
+                    description: repo is the helm repository URL to sync from. Required.
+                    type: string
+                  secretRef:
+                    description: secretRef holds the authentication secret for accessing the Helm repository.
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  values:
+                    description: values to use instead of default values that accompany the chart
+                    type: object
+                  valuesFiles:
+                    description: valuesFiles is a list of path to Helm value files. Values files must be in the same repository with the Helm chart. And the paths here are absolute path from the root directory of the repository
+                    items:
+                      type: string
+                    type: array
+                  version:
+                    description: version is the chart version. If this is not specified, the latest version is used
+                    type: string
+                required:
+                - auth
+                - chart
+                - repo
+                type: object
+              oci:
+                description: oci contains configuration specific to importing resources from an OCI package.
+                properties:
+                  auth:
+                    description: auth is the type of secret configured for access to the OCI package. Must be one of gcenode, gcpserviceaccount, or none. The validation of this is case-sensitive. Required.
+                    enum:
+                    - gcenode
+                    - gcpserviceaccount
+                    - none
+                    type: string
+                  dir:
+                    description: 'dir is the absolute path of the directory that contains the local resources.  Default: the root directory of the image.'
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when secretType: gcpServiceAccount.'
+                    type: string
+                  image:
+                    description: 'image is the OCI image repository URL for the package to sync from. e.g. `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME`. The image can be pulled by TAG or by DIGEST if it is specified in PACKAGE_NAME. - Pull by tag: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME:TAG`. - Pull by digest: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME@sha256:DIGEST`. If neither TAG nor DIGEST is specified, it pulls with the `latest` tag by default. Required'
+                    type: string
+                  period:
+                    description: 'period is the time duration between consecutive syncs. Default: 15s. Note to developers that customers specify this value using string (https://golang.org/pkg/time/#Duration.String) like "3s" in their Custom Resource YAML. However, time.Duration is at a nanosecond granularity, and it is easy to introduce a bug where it looks like the code is dealing with seconds but its actually nanoseconds (or vice versa).'
+                    type: string
+                required:
+                - auth
+                - image
+                type: object
+              override:
+                description: override allows to override the settings for a reconciler.
+                nullable: true
+                properties:
+                  enableShellInRendering:
+                    description: 'enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false. Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and support pulling remote bases from public repositories.'
+                    type: boolean
+                  gitSyncDepth:
+                    description: gitSyncDepth allows one to override the number of git commits to fetch. Must be no less than 0. Config Sync would do a full clone if this field is 0, and a shallow clone if this field is greater than 0. If this field is not provided, Config Sync would configure it automatically.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  reconcileTimeout:
+                    description: 'reconcileTimeout allows one to override the threshold for how long to wait for all resources to reconcile before giving up. Default: 5m. Use string to specify this field value, like "30s", "5m". More details about valid inputs: https://pkg.go.dev/time#ParseDuration. Recommended reconcileTimeout range is from "10s" to "1h".'
+                    type: string
+                  resources:
+                    description: resources allow one to override the resource requirements for the containers in a reconciler pod.
+                    items:
+                      description: ContainerResourcesSpec allows to override the resource requirements for a container
+                      properties:
+                        containerName:
+                          description: containerName specifies the name of a container whose resource requirements will be overridden. Must be "reconciler", "git-sync", "hydration-controller", or "oci-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync)$
+                          type: string
+                        cpuLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuLimit allows one to override the CPU limit of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        cpuRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuRequest allows one to override the CPU request of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryLimit allows one to override the memory limit of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryRequest allows one to override the memory request of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type: array
+                  statusMode:
+                    description: statusMode controls whether the actuation status such as apply failed or not should be embedded into the ResourceGroup object. Must be "enabled" or "disabled". If set to "enabled", it increases the size of the ResourceGroup object.
+                    pattern: ^(enabled|disabled|)$
+                    type: string
+                type: object
+              sourceFormat:
+                description: "sourceFormat specifies how the repository is formatted. See documentation for specifics of what these options do. \n Must be one of hierarchy, unstructured. Optional. Set to hierarchy if not specified. \n The validation of this is case-sensitive."
+                pattern: ^(hierarchy|unstructured|)$
+                type: string
+              sourceType:
+                default: git
+                description: "sourceType specifies the type of the source of truth. \n Must be one of git, oci, helm. Optional. Set to git if not specified."
+                pattern: ^(git|oci|helm)$
+                type: string
+            type: object
+          status:
+            description: RootSyncStatus defines the observed state of RootSync
+            properties:
+              conditions:
+                description: conditions represents the latest available observations of the RootSync's current state.
+                items:
+                  description: RootSyncCondition describes the state of a RootSync at a certain point.
+                  properties:
+                    commit:
+                      description: hash of the source of truth. It can be a git commit hash, or an OCI image digest.
+                      type: string
+                    errorSourceRefs:
+                      description: errorSourceRefs track the origination(s) of errors when the condition type is Syncing.
+                      items:
+                        description: ErrorSource indicates the origination of errors.
+                        type: string
+                      type: array
+                    errorSummary:
+                      description: errorSummary summarizes the errors in the `errors` field when the condition type is Reconciling or Stalled, and summarizes the errors referred in the `errorsSourceRefs` field when the condition type is Syncing.
+                      properties:
+                        errorCountAfterTruncation:
+                          description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                          type: integer
+                        totalCount:
+                          description: totalCount tracks the total number of errors.
+                          type: integer
+                        truncated:
+                          description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                          type: boolean
+                      type: object
+                    errors:
+                      description: errors is a list of errors that occurred in the process. This field is used to track errors when the condition type is Reconciling or Stalled. When the condition type is Syncing, the `errorSourceRefs` field is used instead to avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
+                      items:
+                        description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                        properties:
+                          code:
+                            description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                            type: string
+                          errorMessage:
+                            description: errorMessage describes the error that occurred.
+                            type: string
+                          errorResources:
+                            description: errorResources describes the resources associated with this error, if any.
+                            items:
+                              description: ResourceRef contains the identification bits of a single managed resource.
+                              properties:
+                                gvk:
+                                  description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                  properties:
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    version:
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - version
+                                  type: object
+                                name:
+                                  description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                  type: string
+                                namespace:
+                                  description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                  type: string
+                                sourcePath:
+                                  description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - code
+                        - errorMessage
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of RootSync condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedCommit:
+                description: lastSyncedCommit describes the most recent hash that is successfully synced. It can be a git commit hash, or an OCI image digest.
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed for the sync resource. It corresponds to the it's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              reconciler:
+                description: reconciler is the name of the reconciler process which corresponds to the sync resource.
+                type: string
+              rendering:
+                description: rendering contains fields describing the status of rendering resources from the source of truth.
+                properties:
+                  commit:
+                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during the process of rendering the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while rendering the source of truth.
+                    items:
+                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      properties:
+                        code:
+                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits of a single managed resource.
+                            properties:
+                              gvk:
+                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  lastUpdate:
+                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Human-readable message describes details about the rendering status.
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    properties:
+                      dir:
+                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              source:
+                description: source contains fields describing the status of a *Sync's source of truth.
+                properties:
+                  commit:
+                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during the process of reading from the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while reading from the source of truth.
+                    items:
+                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      properties:
+                        code:
+                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits of a single managed resource.
+                            properties:
+                              gvk:
+                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  lastUpdate:
+                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    properties:
+                      dir:
+                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              sync:
+                description: sync contains fields describing the status of syncing resources from the source of truth to the cluster.
+                properties:
+                  commit:
+                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during the process of syncing the resources.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while applying the resources from the change indicated by Commit.
+                    items:
+                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      properties:
+                        code:
+                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits of a single managed resource.
+                            properties:
+                              gvk:
+                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  lastUpdate:
+                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    properties:
+                      dir:
+                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .status.rendering.commit
+      name: RenderingCommit
+      type: string
+    - jsonPath: .status.rendering.errorSummary.totalCount
+      name: RenderingErrorCount
+      type: integer
+    - jsonPath: .status.source.commit
+      name: SourceCommit
+      type: string
+    - jsonPath: .status.source.errorSummary.totalCount
+      name: SourceErrorCount
+      type: integer
+    - jsonPath: .status.sync.commit
+      name: SyncCommit
+      type: string
+    - jsonPath: .status.sync.errorSummary.totalCount
+      name: SyncErrorCount
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: RootSync is the Schema for the rootsyncs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RootSyncSpec defines the desired state of RootSync
+            properties:
+              git:
+                description: git contains configuration specific to importing resources from a Git repo.
+                properties:
+                  auth:
+                    description: auth is the type of secret configured for access to the Git repo. Must be one of ssh, cookiefile, gcenode, token, or none. The validation of this is case-sensitive. Required.
+                    enum:
+                    - ssh
+                    - cookiefile
+                    - gcenode
+                    - gcpserviceaccount
+                    - token
+                    - none
+                    type: string
+                  branch:
+                    description: 'branch is the git branch to checkout. Default: "master".'
+                    type: string
+                  dir:
+                    description: 'dir is the absolute path of the directory that contains the local resources.  Default: the root directory of the repo.'
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when secretType: gcpServiceAccount.'
+                    type: string
+                  noSSLVerify:
+                    description: 'noSSLVerify specifies whether to enable or disable the SSL certificate verification. Default: false. If noSSLVerify is set to true, it tells Git to skip the SSL certificate verification.'
+                    type: boolean
+                  period:
+                    description: 'period is the time duration between consecutive syncs. Default: 15s. Note to developers that customers specify this value using string (https://golang.org/pkg/time/#Duration.String) like "3s" in their Custom Resource YAML. However, time.Duration is at a nanosecond granularity, and it is easy to introduce a bug where it looks like the code is dealing with seconds but its actually nanoseconds (or vice versa).'
+                    type: string
+                  proxy:
+                    description: proxy specifies an HTTPS proxy for accessing the Git repo. Only has an effect when secretType is one of ("cookiefile", "none", "token"). When secretType is "cookiefile" or "token", if your HTTPS proxy URL contains sensitive information such as a username or password and you need to hide the sensitive information, you can leave this field empty and add the URL for the HTTPS proxy into the same Secret used for the Git credential via `kubectl create secret ... --from-literal=https_proxy=HTTPS_PROXY_URL`. Optional.
+                    type: string
+                  repo:
+                    description: repo is the git repository URL to sync from. Required.
+                    type: string
+                  revision:
+                    description: 'revision is the git revision (tag, ref or commit) to fetch. Default: "HEAD".'
+                    type: string
+                  secretRef:
+                    description: secretRef is the secret used to connect to the Git source of truth.
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                required:
+                - auth
+                - repo
+                type: object
+              helm:
+                description: helm contains configuration specific to importing resources from a Helm repo.
+                properties:
+                  auth:
+                    description: auth specifies the type to authenticate to the Helm repository. Must be one of secret, gcpserviceaccount, or none. The validation of this is case-sensitive. Required.
+                    enum:
+                    - none
+                    - gcpserviceaccount
+                    - token
+                    type: string
+                  chart:
+                    description: chart is a Helm chart name. Required.
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when spec.helm.auth: gcpserviceaccount.'
+                    type: string
+                  includeCRDs:
+                    description: 'includeCRDs specifies if Helm template should also generate CustomResourceDefinitions. If IncludeCRDs is set to false, no CustomeResourceDefinition will be generated. Default: false.'
+                    type: boolean
+                  namespace:
+                    description: namespace sets the target namespace for a release
+                    type: string
+                  period:
+                    description: 'period is the time duration between consecutive syncs. Default: 15s. Use string to specify this field value, like "30s", "5m". More details about valid inputs: https://pkg.go.dev/time#ParseDuration. Chart will not be re-synced if version is specified and it is not "latest"'
+                    type: string
+                  releaseName:
+                    description: releaseName is the name of the Helm release.
+                    type: string
+                  repo:
+                    description: repo is the helm repository URL to sync from. Required.
+                    type: string
+                  secretRef:
+                    description: secretRef holds the authentication secret for accessing the Helm repository.
+                    properties:
+                      name:
+                        description: name represents the secret name.
+                        type: string
+                    type: object
+                  values:
+                    description: values to use instead of default values that accompany the chart
+                    type: object
+                  valuesFiles:
+                    description: valuesFiles is a list of path to Helm value files. Values files must be in the same repository with the Helm chart. And the paths here are absolute path from the root directory of the repository
+                    items:
+                      type: string
+                    type: array
+                  version:
+                    description: version is the chart version. If this is not specified, the latest version is used
+                    type: string
+                required:
+                - auth
+                - chart
+                - repo
+                type: object
+              oci:
+                description: oci contains configuration specific to importing resources from an OCI package.
+                properties:
+                  auth:
+                    description: auth is the type of secret configured for access to the OCI package. Must be one of gcenode, gcpserviceaccount, or none. The validation of this is case-sensitive. Required.
+                    enum:
+                    - gcenode
+                    - gcpserviceaccount
+                    - none
+                    type: string
+                  dir:
+                    description: 'dir is the absolute path of the directory that contains the local resources.  Default: the root directory of the image.'
+                    type: string
+                  gcpServiceAccountEmail:
+                    description: 'gcpServiceAccountEmail specifies the GCP service account used to annotate the RootSync/RepoSync controller Kubernetes Service Account. Note: The field is used when secretType: gcpServiceAccount.'
+                    type: string
+                  image:
+                    description: 'image is the OCI image repository URL for the package to sync from. e.g. `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME`. The image can be pulled by TAG or by DIGEST if it is specified in PACKAGE_NAME. - Pull by tag: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME:TAG`. - Pull by digest: `LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/PACKAGE_NAME@sha256:DIGEST`. If neither TAG nor DIGEST is specified, it pulls with the `latest` tag by default. Required'
+                    type: string
+                  period:
+                    description: 'period is the time duration between consecutive syncs. Default: 15s. Note to developers that customers specify this value using string (https://golang.org/pkg/time/#Duration.String) like "3s" in their Custom Resource YAML. However, time.Duration is at a nanosecond granularity, and it is easy to introduce a bug where it looks like the code is dealing with seconds but its actually nanoseconds (or vice versa).'
+                    type: string
+                required:
+                - auth
+                - image
+                type: object
+              override:
+                description: override allows to override the settings for a root reconciler.
+                nullable: true
+                properties:
+                  enableShellInRendering:
+                    description: 'enableShellInRendering specifies whether to enable or disable the shell access in rendering process. Default: false. Kustomize remote bases requires shell access. Setting this field to true will enable shell in the rendering process and support pulling remote bases from public repositories.'
+                    type: boolean
+                  gitSyncDepth:
+                    description: gitSyncDepth allows one to override the number of git commits to fetch. Must be no less than 0. Config Sync would do a full clone if this field is 0, and a shallow clone if this field is greater than 0. If this field is not provided, Config Sync would configure it automatically.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  reconcileTimeout:
+                    description: 'reconcileTimeout allows one to override the threshold for how long to wait for all resources to reconcile before giving up. Default: 5m. Use string to specify this field value, like "30s", "5m". More details about valid inputs: https://pkg.go.dev/time#ParseDuration. Recommended reconcileTimeout range is from "10s" to "1h".'
+                    type: string
+                  resources:
+                    description: resources allow one to override the resource requirements for the containers in a reconciler pod.
+                    items:
+                      description: ContainerResourcesSpec allows to override the resource requirements for a container
+                      properties:
+                        containerName:
+                          description: containerName specifies the name of a container whose resource requirements will be overridden. Must be "reconciler", "git-sync", "hydration-controller", or "oci-sync".
+                          pattern: ^(reconciler|git-sync|hydration-controller|oci-sync)$
+                          type: string
+                        cpuLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuLimit allows one to override the CPU limit of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        cpuRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: cpuRequest allows one to override the CPU request of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryLimit allows one to override the memory limit of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        memoryRequest:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: memoryRequest allows one to override the memory request of a container
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    type: array
+                  statusMode:
+                    description: statusMode controls whether the actuation status such as apply failed or not should be embedded into the ResourceGroup object. Must be "enabled" or "disabled". If set to "enabled", it increases the size of the ResourceGroup object.
+                    pattern: ^(enabled|disabled|)$
+                    type: string
+                type: object
+              sourceFormat:
+                description: "sourceFormat specifies how the repository is formatted. See documentation for specifics of what these options do. \n Must be one of hierarchy, unstructured. Optional. Set to hierarchy if not specified. \n The validation of this is case-sensitive."
+                pattern: ^(hierarchy|unstructured|)$
+                type: string
+              sourceType:
+                default: git
+                description: "sourceType specifies the type of the source of truth. \n Must be one of git, oci, helm. Optional. Set to git if not specified."
+                pattern: ^(git|oci|helm)$
+                type: string
+            type: object
+          status:
+            description: RootSyncStatus defines the observed state of RootSync
+            properties:
+              conditions:
+                description: conditions represents the latest available observations of the RootSync's current state.
+                items:
+                  description: RootSyncCondition describes the state of a RootSync at a certain point.
+                  properties:
+                    commit:
+                      description: hash of the source of truth. It can be a git commit hash, or an OCI image digest.
+                      type: string
+                    errorSourceRefs:
+                      description: errorSourceRefs track the origination(s) of errors when the condition type is Syncing.
+                      items:
+                        description: ErrorSource indicates the origination of errors.
+                        type: string
+                      type: array
+                    errorSummary:
+                      description: errorSummary summarizes the errors in the `errors` field when the condition type is Reconciling or Stalled, and summarizes the errors referred in the `errorsSourceRefs` field when the condition type is Syncing.
+                      properties:
+                        errorCountAfterTruncation:
+                          description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                          type: integer
+                        totalCount:
+                          description: totalCount tracks the total number of errors.
+                          type: integer
+                        truncated:
+                          description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                          type: boolean
+                      type: object
+                    errors:
+                      description: errors is a list of errors that occurred in the process. This field is used to track errors when the condition type is Reconciling or Stalled. When the condition type is Syncing, the `errorSourceRefs` field is used instead to avoid duplicating errors between `status.conditions` and `status.rendering|source|sync`.
+                      items:
+                        description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                        properties:
+                          code:
+                            description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                            type: string
+                          errorMessage:
+                            description: errorMessage describes the error that occurred.
+                            type: string
+                          errorResources:
+                            description: errorResources describes the resources associated with this error, if any.
+                            items:
+                              description: ResourceRef contains the identification bits of a single managed resource.
+                              properties:
+                                gvk:
+                                  description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                  properties:
+                                    group:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    version:
+                                      type: string
+                                  required:
+                                  - group
+                                  - kind
+                                  - version
+                                  type: object
+                                name:
+                                  description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                  type: string
+                                namespace:
+                                  description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                  type: string
+                                sourcePath:
+                                  description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - code
+                        - errorMessage
+                        type: object
+                      type: array
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: type of RootSync condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastSyncedCommit:
+                description: lastSyncedCommit describes the most recent hash that is successfully synced. It can be a git commit hash, or an OCI image digest.
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed for the sync resource. It corresponds to the it's generation, which is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              reconciler:
+                description: reconciler is the name of the reconciler process which corresponds to the sync resource.
+                type: string
+              rendering:
+                description: rendering contains fields describing the status of rendering resources from the source of truth.
+                properties:
+                  commit:
+                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during the process of rendering the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while rendering the source of truth.
+                    items:
+                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      properties:
+                        code:
+                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits of a single managed resource.
+                            properties:
+                              gvk:
+                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  lastUpdate:
+                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Human-readable message describes details about the rendering status.
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    properties:
+                      dir:
+                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              source:
+                description: source contains fields describing the status of a *Sync's source of truth.
+                properties:
+                  commit:
+                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during the process of reading from the source of truth.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while reading from the source of truth.
+                    items:
+                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      properties:
+                        code:
+                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits of a single managed resource.
+                            properties:
+                              gvk:
+                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  lastUpdate:
+                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    properties:
+                      dir:
+                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+              sync:
+                description: sync contains fields describing the status of syncing resources from the source of truth to the cluster.
+                properties:
+                  commit:
+                    description: hash of the source of truth that is rendered. It can be a git commit hash, or an OCI image digest.
+                    type: string
+                  errorSummary:
+                    description: errorSummary summarizes the errors encountered during the process of syncing the resources.
+                    properties:
+                      errorCountAfterTruncation:
+                        description: errorCountAfterTruncation tracks the number of errors in the `Errors` field.
+                        type: integer
+                      totalCount:
+                        description: totalCount tracks the total number of errors.
+                        type: integer
+                      truncated:
+                        description: truncated indicates whether the `Errors` field includes all the errors. If `true`, the `Errors` field does not includes all the errors. If `false`, the `Errors` field includes all the errors. The size limit of a RootSync/RepoSync object is 2MiB. The status update would fail with the `ResourceExhausted` rpc error if there are too many errors.
+                        type: boolean
+                    type: object
+                  errors:
+                    description: errors is a list of any errors that occurred while applying the resources from the change indicated by Commit.
+                    items:
+                      description: ConfigSyncError represents an error that occurs while parsing, applying, or remediating a resource.
+                      properties:
+                        code:
+                          description: code is the error code of this particular error.  Error codes are numeric strings, like "1012".
+                          type: string
+                        errorMessage:
+                          description: errorMessage describes the error that occurred.
+                          type: string
+                        errorResources:
+                          description: errorResources describes the resources associated with this error, if any.
+                          items:
+                            description: ResourceRef contains the identification bits of a single managed resource.
+                            properties:
+                              gvk:
+                                description: gvk is the GroupVersionKind of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                properties:
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  version:
+                                    type: string
+                                required:
+                                - group
+                                - kind
+                                - version
+                                type: object
+                              name:
+                                description: name is the name of the affected K8S resource. This field may be empty for errors that are not associated with a specific resource.
+                                type: string
+                              namespace:
+                                description: namespace is the namespace of the affected K8S resource. This field may be empty for errors that are associated with a cluster-scoped resource or not associated with a specific resource.
+                                type: string
+                              sourcePath:
+                                description: sourcePath is the repo-relative slash path to where the config is defined. This field may be empty for errors that are not associated with a specific config file.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - code
+                      - errorMessage
+                      type: object
+                    type: array
+                  gitStatus:
+                    description: gitStatus contains fields describing the status of a Git source of truth.
+                    properties:
+                      branch:
+                        description: branch is the git branch being fetched
+                        type: string
+                      dir:
+                        description: 'dir is the path within the Git repository that represents the top level of the repo to sync. Default: the root directory of the repository'
+                        type: string
+                      repo:
+                        description: repo is the git repository URL being synced from.
+                        type: string
+                      revision:
+                        description: revision is the git revision (tag, ref, or commit) being fetched.
+                        type: string
+                    required:
+                    - branch
+                    - dir
+                    - repo
+                    - revision
+                    type: object
+                  lastUpdate:
+                    description: lastUpdate is the timestamp of when this status was last updated by a reconciler.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  ociStatus:
+                    description: ociStatus contains fields describing the status of an OCI source of truth.
+                    properties:
+                      dir:
+                        description: 'dir is the absolute path of the directory that contains the local resources. Default: the root directory of the repository'
+                        type: string
+                      image:
+                        description: image is the OCI image repository URL for the package to sync from.
+                        type: string
+                    required:
+                    - dir
+                    - image
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio-r1-base/nephio-controllers/Kptfile
+++ b/nephio-r1-base/nephio-controllers/Kptfile
@@ -1,0 +1,22 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: nephio-controllers
+  annotations:
+    config.kubernetes.io/local-config: "true"
+upstream:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /nephio-controllers
+    ref: nephio-controllers/v1
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /nephio-controllers
+    ref: nephio-controllers/v1
+    commit: db1ce6c1a207991fafbb65e996e1130763759e20
+info:
+  description: nephio controller

--- a/nephio-r1-base/nephio-controllers/README.md
+++ b/nephio-r1-base/nephio-controllers/README.md
@@ -1,0 +1,21 @@
+# nephio
+
+## Description
+nephio controller
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] nephio`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree nephio`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init nephio
+kpt live apply nephio --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/nephio-r1-base/nephio-controllers/app/Kptfile
+++ b/nephio-r1-base/nephio-controllers/app/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: nephio app

--- a/nephio-r1-base/nephio-controllers/app/README.md
+++ b/nephio-r1-base/nephio-controllers/app/README.md
@@ -1,0 +1,21 @@
+# app
+
+## Description
+nephio app
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] app`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree app`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init app
+kpt live apply app --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/nephio-r1-base/nephio-controllers/app/controller/clusterrole-bootstrap.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/clusterrole-bootstrap.yaml
@@ -1,0 +1,56 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /nephio-controller-bootstrap-role
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller-bootstrap-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|nephio-controller-bootstrap-role'
+rules:
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - '*'
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - porch.kpt.dev
+  resources:
+  - packagerevisionresources
+  - packagerevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - porch.kpt.dev
+  resources:
+  - packagerevisionresources/status
+  - packagerevisions/status
+  - packagerevisions/approval
+  verbs:
+  - get

--- a/nephio-r1-base/nephio-controllers/app/controller/clusterrole-controller.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/clusterrole-controller.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /nephio-controller-controller-role
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller-controller-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|nephio-controller-controller-role'
+rules: null

--- a/nephio-r1-base/nephio-controllers/app/controller/clusterrole-repository.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/clusterrole-repository.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /nephio-controller-repository-role
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller-repository-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|nephio-controller-repository-role'
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infra.nephio.org
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - infra.nephio.org
+  resources:
+  - repositories/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete

--- a/nephio-r1-base/nephio-controllers/app/controller/clusterrole-token.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/clusterrole-token.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /nephio-controller-token-role
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller-token-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|nephio-controller-token-role'
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infra.nephio.org
+  resources:
+  - tokens
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - infra.nephio.org
+  resources:
+  - tokens/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete

--- a/nephio-r1-base/nephio-controllers/app/controller/clusterrolebinding-bootstrap.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/clusterrolebinding-bootstrap.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /nephio-controller-bootstrap-role-binding
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller-bootstrap-role-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|nephio-controller-bootstrap-role-binding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nephio-controller-bootstrap-role
+subjects:
+- kind: ServiceAccount
+  name: nephio-controller
+  namespace: nephio-system

--- a/nephio-r1-base/nephio-controllers/app/controller/clusterrolebinding-controller.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/clusterrolebinding-controller.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /nephio-controller-controller-role-binding
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller-controller-role-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|nephio-controller-controller-role-binding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nephio-controller-controller-role
+subjects:
+- kind: ServiceAccount
+  name: nephio-controller
+  namespace: nephio-system

--- a/nephio-r1-base/nephio-controllers/app/controller/clusterrolebinding-repository.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/clusterrolebinding-repository.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /nephio-controller-repository-role-binding
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller-repository-role-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|nephio-controller-repository-role-binding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nephio-controller-repository-role
+subjects:
+- kind: ServiceAccount
+  name: nephio-controller
+  namespace: nephio-system

--- a/nephio-r1-base/nephio-controllers/app/controller/clusterrolebinding-token.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/clusterrolebinding-token.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /nephio-controller-token-role-binding
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller-token-role-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|nephio-controller-token-role-binding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nephio-controller-token-role
+subjects:
+- kind: ServiceAccount
+  name: nephio-controller
+  namespace: nephio-system

--- a/nephio-r1-base/nephio-controllers/app/controller/deployment-controller.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/deployment-controller.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: nephio-system/nephio-controller
+  creationTimestamp: null
+  name: nephio-controller
+  namespace: nephio-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|nephio-system|nephio-controller'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      fn.kptgen.dev/controller: nephio-controller
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: tbd
+        app.kubernetes.io/instance: tbd
+        app.kubernetes.io/managed-by: kpt
+        app.kubernetes.io/name: nephio
+        app.kubernetes.io/part-of: nephio
+        app.kubernetes.io/version: tbd
+        fn.kptgen.dev/controller: nephio-controller
+      name: nephio-controller
+      namespace: nephio-system
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+        resources: {}
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: GIT_URL
+          value: http://172.18.0.200:3000
+        - name: ENABLE_REPOSITORIES
+          value: "true"
+        - name: ENABLE_TOKENS
+          value: "true"
+        - name: ENABLE_BOOTSTRAPSECRETS
+          value: "true"
+        - name: ENABLE_BOOTSTRAPPACKAGES
+          value: "true"
+        image: docker.io/nephio/nephio-operator:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: controller
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      serviceAccountName: nephio-controller
+status: {}

--- a/nephio-r1-base/nephio-controllers/app/controller/role-leader-election.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/role-leader-election.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: # kpt-merge: nephio-system/nephio-controller-leader-election-role
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller-leader-election-role
+  namespace: nephio-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|nephio-system|nephio-controller-leader-election-role'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/nephio-r1-base/nephio-controllers/app/controller/rolebinding-leader-election.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/rolebinding-leader-election.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: nephio-system/nephio-controller-leader-election-role-binding
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller-leader-election-role-binding
+  namespace: nephio-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|nephio-system|nephio-controller-leader-election-role-binding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nephio-controller-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: nephio-controller
+  namespace: nephio-system

--- a/nephio-r1-base/nephio-controllers/app/controller/serviceaccount-controller.yaml
+++ b/nephio-r1-base/nephio-controllers/app/controller/serviceaccount-controller.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata: # kpt-merge: nephio-system/nephio-controller
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: nephio
+    app.kubernetes.io/part-of: nephio
+    app.kubernetes.io/version: tbd
+  name: nephio-controller
+  namespace: nephio-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|nephio-system|nephio-controller'

--- a/nephio-r1-base/nephio-controllers/crd/Kptfile
+++ b/nephio-r1-base/nephio-controllers/crd/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: crd
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: nephio crd

--- a/nephio-r1-base/nephio-controllers/crd/README.md
+++ b/nephio-r1-base/nephio-controllers/crd/README.md
@@ -1,0 +1,21 @@
+# crd
+
+## Description
+nephio crd
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] crd`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree crd`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init crd
+kpt live apply crd --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/nephio-r1-base/nephio-controllers/crd/bases/infra.nephio.org_repositories.yaml
+++ b/nephio-r1-base/nephio-controllers/crd/bases/infra.nephio.org_repositories.yaml
@@ -1,0 +1,133 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /repositories.infra.nephio.org
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|repositories.infra.nephio.org'
+  creationTimestamp: null
+  name: repositories.infra.nephio.org
+spec:
+  group: infra.nephio.org
+  names:
+    kind: Repository
+    listKind: RepositoryList
+    plural: repositories
+    singular: repository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: REPO_STATUS
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Repository is the Schema for the repository API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RepositorySpec defines the desired state of Repository
+            properties:
+              defaultBranch:
+                description: DefaultBranch of the repository (used when initializes and in template)
+                type: string
+              description:
+                description: Description of the repository to create
+                type: string
+              gitignores:
+                description: Gitignores defines the Gitignores of the repository
+                type: string
+              issueLabels:
+                description: IssueLabels defines the Issue Label set to use
+                type: string
+              license:
+                description: License to use
+                type: string
+              lifecycle:
+                description: Lifecycle determines the deletion lifecycle policies the resource will follow
+                properties:
+                  deletionPolicy:
+                    default: delete
+                    description: DeletionPolicy specifies what will happen to the underlying resource when this resource is deleted - either "delete" or "orphan" the resource.
+                    enum:
+                    - delete
+                    - orphan
+                    type: string
+                type: object
+              private:
+                description: Private defines whether the repository is private
+                type: boolean
+              readme:
+                description: Readme of the repository to create
+                type: string
+              trustModel:
+                description: TrustModel of the repository
+                enum:
+                - default
+                - collaborator
+                - committer
+                - collaboratorcommitter
+                type: string
+            type: object
+          status:
+            description: RepositoryStatus defines the observed state of Repository
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              url:
+                description: URL is the url for the repo
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio-r1-base/nephio-controllers/crd/bases/infra.nephio.org_tokens.yaml
+++ b/nephio-r1-base/nephio-controllers/crd/bases/infra.nephio.org_tokens.yaml
@@ -1,0 +1,101 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /tokens.infra.nephio.org
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|tokens.infra.nephio.org'
+  creationTimestamp: null
+  name: tokens.infra.nephio.org
+spec:
+  group: infra.nephio.org
+  names:
+    kind: Token
+    listKind: TokenList
+    plural: tokens
+    singular: token
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: REPO_TOKEN_STATUS
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Token is the Schema for the repository token API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TokenSpec defines the desired state of Token
+            properties:
+              lifecycle:
+                description: Lifecycle determines the deletion lifecycle policies the resource will follow
+                properties:
+                  deletionPolicy:
+                    default: delete
+                    description: DeletionPolicy specifies what will happen to the underlying resource when this resource is deleted - either "delete" or "orphan" the resource.
+                    enum:
+                    - delete
+                    - orphan
+                    type: string
+                type: object
+            type: object
+          status:
+            description: TokenStatus defines the observed state of the Token
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio-r1-base/nephio-controllers/namespace.yaml
+++ b/nephio-r1-base/nephio-controllers/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /nephio-system
+  name: nephio-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|nephio-system'

--- a/nephio-r1-base/nephio-webui/0-namespace.yaml
+++ b/nephio-r1-base/nephio-webui/0-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /nephio-webui
+  name: nephio-webui
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|nephio-webui'

--- a/nephio-r1-base/nephio-webui/Kptfile
+++ b/nephio-r1-base/nephio-webui/Kptfile
@@ -1,0 +1,24 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: nephio-webui
+  annotations:
+    config.kubernetes.io/local-config: "true"
+upstream:
+  type: git
+  git:
+    repo: https://github.com/johnbelamaric/nephio-packages
+    directory: /nephio-webui
+    ref: pv-pvs-viewers
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/johnbelamaric/nephio-packages
+    directory: /nephio-webui
+    ref: pv-pvs-viewers
+    commit: 1d62e102fd086ef478fa0d2198ffb68372472e33
+info:
+  site: https://nephio.org
+  description: Package for the Nephio Web UI.
+pipeline: {}

--- a/nephio-r1-base/nephio-webui/README.md
+++ b/nephio-r1-base/nephio-webui/README.md
@@ -1,0 +1,4 @@
+# nephio-webui
+
+## Description
+Package for the Nephio Web UI.

--- a/nephio-r1-base/nephio-webui/cluster-role-binding.yaml
+++ b/nephio-r1-base/nephio-webui/cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /nephio-webui
+  name: nephio-webui
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|nephio-webui'
+subjects:
+- kind: ServiceAccount
+  name: nephio-webui-sa
+  namespace: nephio-webui
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: ""

--- a/nephio-r1-base/nephio-webui/config-map.yaml
+++ b/nephio-r1-base/nephio-webui/config-map.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: nephio-webui/nephio-webui-config
+  name: nephio-webui-config
+  namespace: nephio-webui
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|nephio-webui|nephio-webui-config'
+data:
+  app-config.nephio.yaml: |
+    # Backstage backend configuration
+    backend:
+      # Note that the baseUrl should be the URL that the browser and other clients
+      # should use when communicating with the backend, i.e. it needs to be
+      # reachable not just from within the backend host, but from all of your
+      # callers. When its value is "http://localhost:7007", it's strictly private
+      # and can't be reached by others.
+      baseUrl: http://localhost:7007 # kpt-set: ${backend-base-url}
+      # Content Security Policy
+      csp:
+        # Allows images to be pulled from GitHub and Nepio
+        img-src: ["'self'", 'data:']
+
+    # Config as Data Plugin configuration
+    configAsData:
+      # The namespace where Porch managed resources live.
+      resourcesNamespace: default
+
+      # Do not use Config Sync
+      gitOpsDeliveryTool: none
+
+      # Management cluster configuration
+      clusterLocatorMethod:
+        # Authenitcate to the K8S API Server with the Pod's Service Account
+        authProvider: current-context
+
+      # Nephio branding customizations
+      branding:
+        title: Nephio
+        header:
+          logoUrl: http://localhost:7007/nephio_logo_colorwhite_horizontal.svg
+          backgroundImageUrl: http://localhost:7007/nephio-background.png

--- a/nephio-r1-base/nephio-webui/deployment.yaml
+++ b/nephio-r1-base/nephio-webui/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: nephio-webui/nephio-webui
+  name: nephio-webui
+  namespace: nephio-webui
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|nephio-webui|nephio-webui'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nephio-webui
+  template:
+    metadata:
+      labels:
+        app: nephio-webui
+    spec:
+      serviceAccountName: nephio-webui-sa
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: main
+        image: nephio/kpt-backstage-plugins:1661717771710369792
+        imagePullPolicy: Always
+        args:
+        - "--config"
+        - /etc/config/app-config.nephio.yaml
+        ports:
+        - name: http
+          containerPort: 7007
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 7007
+      volumes:
+      - name: config-volume
+        configMap:
+          name: nephio-webui-config

--- a/nephio-r1-base/nephio-webui/package-context.yaml
+++ b/nephio-r1-base/nephio-webui/package-context.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: /kptfile.kpt.dev
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|kptfile.kpt.dev'
+data:
+  name: example

--- a/nephio-r1-base/nephio-webui/service-account.yaml
+++ b/nephio-r1-base/nephio-webui/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata: # kpt-merge: nephio-webui/nephio-webui-sa
+  name: nephio-webui-sa
+  namespace: nephio-webui
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|nephio-webui|nephio-webui-sa'

--- a/nephio-r1-base/nephio-webui/service.yaml
+++ b/nephio-r1-base/nephio-webui/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata: # kpt-merge: nephio-webui/nephio-webui
+  name: nephio-webui
+  namespace: nephio-webui
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|nephio-webui|nephio-webui'
+spec:
+  selector:
+    app: nephio-webui
+  ports:
+    - name: http
+      port: 7007
+      targetPort: http

--- a/nephio-r1-base/package-context.yaml
+++ b/nephio-r1-base/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: example

--- a/nephio-r1-base/porch/0-packagerevs.yaml
+++ b/nephio-r1-base/porch/0-packagerevs.yaml
@@ -1,0 +1,47 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /packagerevs.config.porch.kpt.dev
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|packagerevs.config.porch.kpt.dev'
+  creationTimestamp: null
+  name: packagerevs.config.porch.kpt.dev
+spec:
+  group: config.porch.kpt.dev
+  names:
+    kind: PackageRev
+    listKind: PackageRevList
+    plural: packagerevs
+    singular: packagerev
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PackageRev
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PackageRevSpec defines the desired state of PackageRev
+            type: object
+          status:
+            description: PackageRevStatus defines the observed state of PackageRev
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/nephio-r1-base/porch/0-packagevariants.yaml
+++ b/nephio-r1-base/porch/0-packagevariants.yaml
@@ -1,0 +1,325 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /packagevariants.config.porch.kpt.dev
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|packagevariants.config.porch.kpt.dev'
+  creationTimestamp: null
+  name: packagevariants.config.porch.kpt.dev
+spec:
+  group: config.porch.kpt.dev
+  names:
+    kind: PackageVariant
+    listKind: PackageVariantList
+    plural: packagevariants
+    singular: packagevariant
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PackageVariant represents an upstream and downstream porch package pair. The upstream package should already exist. The PackageVariant controller is responsible for creating the downstream package revisions based on the spec.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PackageVariantSpec defines the desired state of PackageVariant
+            properties:
+              adoptionPolicy:
+                type: string
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              deletionPolicy:
+                type: string
+              downstream:
+                properties:
+                  package:
+                    type: string
+                  repo:
+                    type: string
+                type: object
+              injectors:
+                items:
+                  description: InjectionSelector specifies how to select in-cluster objects for resolving injection points.
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
+              packageContext:
+                description: PackageContext defines the data to be added or removed from the kptfile.kpt.dev ConfigMap during reconciliation.
+                properties:
+                  data:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  removeKeys:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              pipeline:
+                description: Pipeline declares a pipeline of functions used to mutate or validate resources.
+                properties:
+                  mutators:
+                    description: Mutators defines a list of of KRM functions that mutate resources.
+                    items:
+                      description: Function specifies a KRM function.
+                      properties:
+                        configMap:
+                          additionalProperties:
+                            type: string
+                          description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
+                          type: object
+                        configPath:
+                          description: '`ConfigPath` specifies a slash-delimited relative path to a file in the current directory containing a KRM resource used as the function config. This resource is excluded when resolving ''sources'', and as a result cannot be operated on by the pipeline.'
+                          type: string
+                        exclude:
+                          description: '`Exclude` are used to specify resources on which the function should NOT be executed. If not specified, all resources selected by `Selectors` are selected.'
+                          items:
+                            description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations on the target resources
+                                type: object
+                              apiVersion:
+                                description: APIVersion of the target resources
+                                type: string
+                              kind:
+                                description: Kind of the target resources
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels on the target resources
+                                type: object
+                              name:
+                                description: Name of the target resources
+                                type: string
+                              namespace:
+                                description: Namespace of the target resources
+                                type: string
+                            type: object
+                          type: array
+                        exec:
+                          description: "Exec specifies the function binary executable. The executable can be fully qualified or it must exists in the $PATH e.g: \n exec: set-namespace exec: /usr/local/bin/my-custom-fn"
+                          type: string
+                        image:
+                          description: "`Image` specifies the function container image. It can either be fully qualified, e.g.: \n image: gcr.io/kpt-fn/set-labels \n Optionally, kpt can be configured to use a image registry host-path that will be used to resolve the image path in case the image path is missing (Defaults to gcr.io/kpt-fn). e.g. The following resolves to gcr.io/kpt-fn/set-labels: \n image: set-labels"
+                          type: string
+                        name:
+                          description: '`Name` is used to uniquely identify the function declaration this is primarily used for merging function declaration with upstream counterparts'
+                          type: string
+                        selectors:
+                          description: '`Selectors` are used to specify resources on which the function should be executed if not specified, all resources are selected'
+                          items:
+                            description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations on the target resources
+                                type: object
+                              apiVersion:
+                                description: APIVersion of the target resources
+                                type: string
+                              kind:
+                                description: Kind of the target resources
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels on the target resources
+                                type: object
+                              name:
+                                description: Name of the target resources
+                                type: string
+                              namespace:
+                                description: Namespace of the target resources
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  validators:
+                    description: Validators defines a list of KRM functions that validate resources. Validators are not permitted to mutate resources.
+                    items:
+                      description: Function specifies a KRM function.
+                      properties:
+                        configMap:
+                          additionalProperties:
+                            type: string
+                          description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
+                          type: object
+                        configPath:
+                          description: '`ConfigPath` specifies a slash-delimited relative path to a file in the current directory containing a KRM resource used as the function config. This resource is excluded when resolving ''sources'', and as a result cannot be operated on by the pipeline.'
+                          type: string
+                        exclude:
+                          description: '`Exclude` are used to specify resources on which the function should NOT be executed. If not specified, all resources selected by `Selectors` are selected.'
+                          items:
+                            description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations on the target resources
+                                type: object
+                              apiVersion:
+                                description: APIVersion of the target resources
+                                type: string
+                              kind:
+                                description: Kind of the target resources
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels on the target resources
+                                type: object
+                              name:
+                                description: Name of the target resources
+                                type: string
+                              namespace:
+                                description: Namespace of the target resources
+                                type: string
+                            type: object
+                          type: array
+                        exec:
+                          description: "Exec specifies the function binary executable. The executable can be fully qualified or it must exists in the $PATH e.g: \n exec: set-namespace exec: /usr/local/bin/my-custom-fn"
+                          type: string
+                        image:
+                          description: "`Image` specifies the function container image. It can either be fully qualified, e.g.: \n image: gcr.io/kpt-fn/set-labels \n Optionally, kpt can be configured to use a image registry host-path that will be used to resolve the image path in case the image path is missing (Defaults to gcr.io/kpt-fn). e.g. The following resolves to gcr.io/kpt-fn/set-labels: \n image: set-labels"
+                          type: string
+                        name:
+                          description: '`Name` is used to uniquely identify the function declaration this is primarily used for merging function declaration with upstream counterparts'
+                          type: string
+                        selectors:
+                          description: '`Selectors` are used to specify resources on which the function should be executed if not specified, all resources are selected'
+                          items:
+                            description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations on the target resources
+                                type: object
+                              apiVersion:
+                                description: APIVersion of the target resources
+                                type: string
+                              kind:
+                                description: Kind of the target resources
+                                type: string
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels on the target resources
+                                type: object
+                              name:
+                                description: Name of the target resources
+                                type: string
+                              namespace:
+                                description: Namespace of the target resources
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              upstream:
+                properties:
+                  package:
+                    type: string
+                  repo:
+                    type: string
+                  revision:
+                    type: string
+                type: object
+            type: object
+          status:
+            description: PackageVariantStatus defines the observed state of PackageVariant
+            properties:
+              conditions:
+                description: Conditions describes the reconciliation state of the object.
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              downstreamTargets:
+                description: DownstreamTargets contains the downstream targets that the PackageVariant either created or adopted.
+                items:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/nephio-r1-base/porch/0-packagevariantsets.yaml
+++ b/nephio-r1-base/porch/0-packagevariantsets.yaml
@@ -1,0 +1,726 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /packagevariantsets.config.porch.kpt.dev
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|packagevariantsets.config.porch.kpt.dev'
+  creationTimestamp: null
+  name: packagevariantsets.config.porch.kpt.dev
+spec:
+  group: config.porch.kpt.dev
+  names:
+    kind: PackageVariantSet
+    listKind: PackageVariantSetList
+    plural: packagevariantsets
+    singular: packagevariantset
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PackageVariantSet represents an upstream package revision and a way to target specific downstream repositories where a variant of the upstream package should be created.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PackageVariantSetSpec defines the desired state of PackageVariantSet
+            properties:
+              adoptionPolicy:
+                type: string
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              deletionPolicy:
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
+              targets:
+                items:
+                  properties:
+                    objects:
+                      description: 'option 3: a selector against a set of arbitrary objects'
+                      properties:
+                        repoName:
+                          properties:
+                            fromField:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        selectors:
+                          items:
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations on the target resources
+                                type: object
+                              apiVersion:
+                                description: APIVersion of the target resources
+                                type: string
+                              kind:
+                                description: Kind of the target resources
+                                type: string
+                              labelSelector:
+                                description: Labels on the target resources
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                              name:
+                                description: Name of the target resources
+                                type: string
+                              namespace:
+                                description: Namespace of the target resources
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    package:
+                      description: 'option 1: an explicit repo/package name pair'
+                      properties:
+                        name:
+                          type: string
+                        repo:
+                          type: string
+                      type: object
+                    packageName:
+                      description: For options 2 and 3, PackageName specifies how to create the name of the package variant
+                      properties:
+                        baseName:
+                          properties:
+                            fromField:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        namePrefix:
+                          properties:
+                            fromField:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        nameSuffix:
+                          properties:
+                            fromField:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                      type: object
+                    repositories:
+                      description: 'option 2: a label selector against a set of repositories'
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              upstream:
+                properties:
+                  package:
+                    properties:
+                      name:
+                        type: string
+                      repo:
+                        type: string
+                    type: object
+                  ref:
+                    type: string
+                  revision:
+                    type: string
+                type: object
+            type: object
+          status:
+            description: PackageVariantSetStatus defines the observed state of PackageVariantSet
+            properties:
+              conditions:
+                description: Conditions describes the reconciliation state of the object.
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: PackageVariantSet represents an upstream package revision and a way to target specific downstream repositories where a variant of the upstream package should be created.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PackageVariantSetSpec defines the desired state of PackageVariantSet
+            properties:
+              targets:
+                items:
+                  properties:
+                    objectSelector:
+                      description: 'option 3: a selector against a set of arbitrary objects'
+                      properties:
+                        apiVersion:
+                          description: APIVersion of the target resources
+                          type: string
+                        kind:
+                          description: Kind of the target resources
+                          type: string
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                        name:
+                          description: Name of the target resource
+                          type: string
+                      type: object
+                    repositories:
+                      description: 'Exactly one of Repositories, RepositorySeletor, and ObjectSelector must be populated option 1: an explicit repositories and package names'
+                      items:
+                        properties:
+                          name:
+                            description: Name contains the name of the Repository resource, which must be in the same namespace as the PackageVariantSet resource.
+                            type: string
+                          packageNames:
+                            description: PackageNames contains names to use for package instances in this repository; that is, the same upstream will be instantiated multiple times using these names.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    repositorySelector:
+                      description: 'option 2: a label selector against a set of repositories'
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    template:
+                      description: Template specifies how to generate a PackageVariant from a target
+                      properties:
+                        adoptionPolicy:
+                          description: AdoptionPolicy allows overriding the PackageVariant adoption policy
+                          type: string
+                        annotationExprs:
+                          description: AnnotationsExprs allows specifying the spec.Annotations field of the generated PackageVariant using CEL to dynamically create the keys and values. Entries in this field take precedent over those with the same keys that are present in Annotations.
+                          items:
+                            description: MapExpr is used for various fields to calculate map entries. Only one of Key and KeyExpr may be specified; similarly only on of Value and ValueExpr may be specified.
+                            properties:
+                              key:
+                                type: string
+                              keyExpr:
+                                type: string
+                              value:
+                                type: string
+                              valueExpr:
+                                type: string
+                            type: object
+                          type: array
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations allows specifying the spec.Annotations field of the generated PackageVariant
+                          type: object
+                        deletionPolicy:
+                          description: DeletionPolicy allows overriding the PackageVariant deletion policy
+                          type: string
+                        downstream:
+                          description: Downstream allows overriding the default downstream package and repository name
+                          properties:
+                            package:
+                              type: string
+                            packageExpr:
+                              type: string
+                            repo:
+                              type: string
+                            repoExpr:
+                              type: string
+                          type: object
+                        injectors:
+                          description: Injectors allows specifying the spec.Injectors field of the generated PackageVariant
+                          items:
+                            description: InjectionSelectorTemplate is used to calculate the injectors field of the resulting package variants. Exactly one of the Name and NameExpr fields must be specified. The other fields are optional.
+                            properties:
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              name:
+                                type: string
+                              nameExpr:
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                          type: array
+                        labelExprs:
+                          description: LabelsExprs allows specifying the spec.Labels field of the generated PackageVariant using CEL to dynamically create the keys and values. Entries in this field take precedent over those with the same keys that are present in Labels.
+                          items:
+                            description: MapExpr is used for various fields to calculate map entries. Only one of Key and KeyExpr may be specified; similarly only on of Value and ValueExpr may be specified.
+                            properties:
+                              key:
+                                type: string
+                              keyExpr:
+                                type: string
+                              value:
+                                type: string
+                              valueExpr:
+                                type: string
+                            type: object
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: Labels allows specifying the spec.Labels field of the generated PackageVariant
+                          type: object
+                        packageContext:
+                          description: PackageContext allows specifying the spec.PackageContext field of the generated PackageVariant
+                          properties:
+                            data:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            dataExprs:
+                              items:
+                                description: MapExpr is used for various fields to calculate map entries. Only one of Key and KeyExpr may be specified; similarly only on of Value and ValueExpr may be specified.
+                                properties:
+                                  key:
+                                    type: string
+                                  keyExpr:
+                                    type: string
+                                  value:
+                                    type: string
+                                  valueExpr:
+                                    type: string
+                                type: object
+                              type: array
+                            removeKeyExprs:
+                              items:
+                                type: string
+                              type: array
+                            removeKeys:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        pipeline:
+                          description: Pipeline allows specifying the spec.Pipeline field of the generated PackageVariant
+                          properties:
+                            mutators:
+                              description: Mutators is used to caculate the pipeline.mutators field of the resulting package variants.
+                              items:
+                                description: FunctionTemplate is used in generating KRM function pipeline entries; that is, it is used to generate Kptfile Function objects.
+                                properties:
+                                  configMap:
+                                    additionalProperties:
+                                      type: string
+                                    description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
+                                    type: object
+                                  configMapExprs:
+                                    description: ConfigMapExprs allows use of CEL to dynamically create the keys and values in the function config ConfigMap. Entries in this field take precedent over those with the same keys that are present in ConfigMap.
+                                    items:
+                                      description: MapExpr is used for various fields to calculate map entries. Only one of Key and KeyExpr may be specified; similarly only on of Value and ValueExpr may be specified.
+                                      properties:
+                                        key:
+                                          type: string
+                                        keyExpr:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueExpr:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  configPath:
+                                    description: '`ConfigPath` specifies a slash-delimited relative path to a file in the current directory containing a KRM resource used as the function config. This resource is excluded when resolving ''sources'', and as a result cannot be operated on by the pipeline.'
+                                    type: string
+                                  exclude:
+                                    description: '`Exclude` are used to specify resources on which the function should NOT be executed. If not specified, all resources selected by `Selectors` are selected.'
+                                    items:
+                                      description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations on the target resources
+                                          type: object
+                                        apiVersion:
+                                          description: APIVersion of the target resources
+                                          type: string
+                                        kind:
+                                          description: Kind of the target resources
+                                          type: string
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Labels on the target resources
+                                          type: object
+                                        name:
+                                          description: Name of the target resources
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the target resources
+                                          type: string
+                                      type: object
+                                    type: array
+                                  exec:
+                                    description: "Exec specifies the function binary executable. The executable can be fully qualified or it must exists in the $PATH e.g: \n exec: set-namespace exec: /usr/local/bin/my-custom-fn"
+                                    type: string
+                                  image:
+                                    description: "`Image` specifies the function container image. It can either be fully qualified, e.g.: \n image: gcr.io/kpt-fn/set-labels \n Optionally, kpt can be configured to use a image registry host-path that will be used to resolve the image path in case the image path is missing (Defaults to gcr.io/kpt-fn). e.g. The following resolves to gcr.io/kpt-fn/set-labels: \n image: set-labels"
+                                    type: string
+                                  name:
+                                    description: '`Name` is used to uniquely identify the function declaration this is primarily used for merging function declaration with upstream counterparts'
+                                    type: string
+                                  selectors:
+                                    description: '`Selectors` are used to specify resources on which the function should be executed if not specified, all resources are selected'
+                                    items:
+                                      description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations on the target resources
+                                          type: object
+                                        apiVersion:
+                                          description: APIVersion of the target resources
+                                          type: string
+                                        kind:
+                                          description: Kind of the target resources
+                                          type: string
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Labels on the target resources
+                                          type: object
+                                        name:
+                                          description: Name of the target resources
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the target resources
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                            validators:
+                              description: Validators is used to caculate the pipeline.validators field of the resulting package variants.
+                              items:
+                                description: FunctionTemplate is used in generating KRM function pipeline entries; that is, it is used to generate Kptfile Function objects.
+                                properties:
+                                  configMap:
+                                    additionalProperties:
+                                      type: string
+                                    description: '`ConfigMap` is a convenient way to specify a function config of kind ConfigMap.'
+                                    type: object
+                                  configMapExprs:
+                                    description: ConfigMapExprs allows use of CEL to dynamically create the keys and values in the function config ConfigMap. Entries in this field take precedent over those with the same keys that are present in ConfigMap.
+                                    items:
+                                      description: MapExpr is used for various fields to calculate map entries. Only one of Key and KeyExpr may be specified; similarly only on of Value and ValueExpr may be specified.
+                                      properties:
+                                        key:
+                                          type: string
+                                        keyExpr:
+                                          type: string
+                                        value:
+                                          type: string
+                                        valueExpr:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  configPath:
+                                    description: '`ConfigPath` specifies a slash-delimited relative path to a file in the current directory containing a KRM resource used as the function config. This resource is excluded when resolving ''sources'', and as a result cannot be operated on by the pipeline.'
+                                    type: string
+                                  exclude:
+                                    description: '`Exclude` are used to specify resources on which the function should NOT be executed. If not specified, all resources selected by `Selectors` are selected.'
+                                    items:
+                                      description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations on the target resources
+                                          type: object
+                                        apiVersion:
+                                          description: APIVersion of the target resources
+                                          type: string
+                                        kind:
+                                          description: Kind of the target resources
+                                          type: string
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Labels on the target resources
+                                          type: object
+                                        name:
+                                          description: Name of the target resources
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the target resources
+                                          type: string
+                                      type: object
+                                    type: array
+                                  exec:
+                                    description: "Exec specifies the function binary executable. The executable can be fully qualified or it must exists in the $PATH e.g: \n exec: set-namespace exec: /usr/local/bin/my-custom-fn"
+                                    type: string
+                                  image:
+                                    description: "`Image` specifies the function container image. It can either be fully qualified, e.g.: \n image: gcr.io/kpt-fn/set-labels \n Optionally, kpt can be configured to use a image registry host-path that will be used to resolve the image path in case the image path is missing (Defaults to gcr.io/kpt-fn). e.g. The following resolves to gcr.io/kpt-fn/set-labels: \n image: set-labels"
+                                    type: string
+                                  name:
+                                    description: '`Name` is used to uniquely identify the function declaration this is primarily used for merging function declaration with upstream counterparts'
+                                    type: string
+                                  selectors:
+                                    description: '`Selectors` are used to specify resources on which the function should be executed if not specified, all resources are selected'
+                                    items:
+                                      description: Selector specifies the selection criteria please update IsEmpty method if more properties are added
+                                      properties:
+                                        annotations:
+                                          additionalProperties:
+                                            type: string
+                                          description: Annotations on the target resources
+                                          type: object
+                                        apiVersion:
+                                          description: APIVersion of the target resources
+                                          type: string
+                                        kind:
+                                          description: Kind of the target resources
+                                          type: string
+                                        labels:
+                                          additionalProperties:
+                                            type: string
+                                          description: Labels on the target resources
+                                          type: object
+                                        name:
+                                          description: Name of the target resources
+                                          type: string
+                                        namespace:
+                                          description: Namespace of the target resources
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                  type: object
+                type: array
+              upstream:
+                properties:
+                  package:
+                    type: string
+                  repo:
+                    type: string
+                  revision:
+                    type: string
+                type: object
+            type: object
+          status:
+            description: PackageVariantSetStatus defines the observed state of PackageVariantSet
+            properties:
+              conditions:
+                description: Conditions describes the reconciliation state of the object.
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/nephio-r1-base/porch/0-repositories.yaml
+++ b/nephio-r1-base/porch/0-repositories.yaml
@@ -1,0 +1,273 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /repositories.config.porch.kpt.dev
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|repositories.config.porch.kpt.dev'
+  creationTimestamp: null
+  name: repositories.config.porch.kpt.dev
+spec:
+  group: config.porch.kpt.dev
+  names:
+    kind: Repository
+    listKind: RepositoryList
+    plural: repositories
+    singular: repository
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .spec.content
+      name: Content
+      type: string
+    - jsonPath: .spec.deployment
+      name: Deployment
+      type: boolean
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec['git','oci']['repo','registry']
+      name: Address
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Repository
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: "RepositorySpec defines the desired state of Repository \n Notes: - deployment repository - in KRM API ConfigSync would be configured directly? (or via this API)"
+            properties:
+              content:
+                description: 'Content stored in the repository (i.e. Function, Package - the literal values correspond to the API resource names). TODO: support repository with mixed content?'
+                type: string
+              deployment:
+                description: The repository is a deployment repository; final packages in this repository are deployment ready.
+                type: boolean
+              description:
+                description: User-friendly description of the repository
+                type: string
+              git:
+                description: Git repository details. Required if `type` is `git`. Ignored if `type` is not `git`.
+                properties:
+                  branch:
+                    description: Name of the branch containing the packages. Finalized packages will be committed to this branch (if the repository allows write access). If unspecified, defaults to "main".
+                    type: string
+                  createBranch:
+                    description: CreateBranch specifies if Porch should create the package branch if it doesn't exist.
+                    type: boolean
+                  directory:
+                    description: Directory within the Git repository where the packages are stored. A subdirectory of this directory containing a Kptfile is considered a package. If unspecified, defaults to root directory.
+                    type: string
+                  repo:
+                    description: 'Address of the Git repository, for example: `https://github.com/GoogleCloudPlatform/blueprints.git`'
+                    type: string
+                  secretRef:
+                    description: Reference to secret containing authentication credentials.
+                    properties:
+                      name:
+                        description: Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - repo
+                type: object
+              mutators:
+                description: '`Mutators` specifies list of functions to be added to the list of package''s mutators on changes to the packages in the repository to ensure the packages meet constraints enforced by the mutators associated with the repository. Based on the Kubernetest Admission Controllers (https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/). The functions will be evaluated in the order specified in the list.'
+                items:
+                  properties:
+                    configMap:
+                      additionalProperties:
+                        type: string
+                      description: '`ConfigMap` specifies the function config (https://kpt.dev/reference/cli/fn/eval/).'
+                      type: object
+                    functionRef:
+                      description: '`FunctionRef` specifies the function by reference to a Function resource. Mutually exclusive with `Image`.'
+                      properties:
+                        name:
+                          description: '`Name` is the name of the `Function` resource referenced. The resource is expected to be within the same namespace.'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    image:
+                      description: '`Image` specifies the function image, such as `gcr.io/kpt-fn/gatekeeper:v0.2`. Use of `Image` is mutually exclusive with `FunctionRef`.'
+                      type: string
+                  type: object
+                type: array
+              oci:
+                description: OCI repository details. Required if `type` is `oci`. Ignored if `type` is not `oci`.
+                properties:
+                  registry:
+                    description: Registry is the address of the OCI registry
+                    type: string
+                  secretRef:
+                    description: Reference to secret containing authentication credentials.
+                    properties:
+                      name:
+                        description: Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - registry
+                type: object
+              type:
+                description: Type of the repository (i.e. git, OCI)
+                type: string
+              upstream:
+                description: Upstream is the default upstream repository for packages in this repository. Specifying it per repository allows simpler UX when creating packages.
+                properties:
+                  git:
+                    description: Git repository details. Required if `type` is `git`. Must be unspecified if `type` is not `git`.
+                    properties:
+                      branch:
+                        description: Name of the branch containing the packages. Finalized packages will be committed to this branch (if the repository allows write access). If unspecified, defaults to "main".
+                        type: string
+                      createBranch:
+                        description: CreateBranch specifies if Porch should create the package branch if it doesn't exist.
+                        type: boolean
+                      directory:
+                        description: Directory within the Git repository where the packages are stored. A subdirectory of this directory containing a Kptfile is considered a package. If unspecified, defaults to root directory.
+                        type: string
+                      repo:
+                        description: 'Address of the Git repository, for example: `https://github.com/GoogleCloudPlatform/blueprints.git`'
+                        type: string
+                      secretRef:
+                        description: Reference to secret containing authentication credentials.
+                        properties:
+                          name:
+                            description: Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - repo
+                    type: object
+                  oci:
+                    description: OCI repository details. Required if `type` is `oci`. Must be unspecified if `type` is not `oci`.
+                    properties:
+                      registry:
+                        description: Registry is the address of the OCI registry
+                        type: string
+                      secretRef:
+                        description: Reference to secret containing authentication credentials.
+                        properties:
+                          name:
+                            description: Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - registry
+                    type: object
+                  repositoryRef:
+                    description: RepositoryRef contains a reference to an existing Repository resource to be used as the default upstream repository.
+                    properties:
+                      name:
+                        description: Name of the Repository resource referenced.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type:
+                    description: Type of the repository (i.e. git, OCI). If empty, repositoryRef will be used.
+                    type: string
+                type: object
+              validators:
+                description: '`Validators` specifies list of functions to be added to the list of package''s validators on changes to the packages in the repository to ensure the packages meet constraints enforced by the validators associated with the repository. Based on the Kubernetest Admission Controllers (https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/). The functions will be evaluated in the order specified in the list.'
+                items:
+                  properties:
+                    configMap:
+                      additionalProperties:
+                        type: string
+                      description: '`ConfigMap` specifies the function config (https://kpt.dev/reference/cli/fn/eval/).'
+                      type: object
+                    functionRef:
+                      description: '`FunctionRef` specifies the function by reference to a Function resource. Mutually exclusive with `Image`.'
+                      properties:
+                        name:
+                          description: '`Name` is the name of the `Function` resource referenced. The resource is expected to be within the same namespace.'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    image:
+                      description: '`Image` specifies the function image, such as `gcr.io/kpt-fn/gatekeeper:v0.2`. Use of `Image` is mutually exclusive with `FunctionRef`.'
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: RepositoryStatus defines the observed state of Repository
+            properties:
+              conditions:
+                description: Conditions describes the reconciliation state of the object.
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/nephio-r1-base/porch/1-namespace.yaml
+++ b/nephio-r1-base/porch/1-namespace.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /porch-system
+  name: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|porch-system'
+---
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /porch-fn-system
+  name: porch-fn-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|porch-fn-system'

--- a/nephio-r1-base/porch/2-function-runner.yaml
+++ b/nephio-r1-base/porch/2-function-runner.yaml
@@ -1,0 +1,115 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ServiceAccount
+apiVersion: v1
+metadata: # kpt-merge: porch-system/porch-fn-runner
+  name: porch-fn-runner
+  namespace: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|porch-system|porch-fn-runner'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: porch-system/function-runner
+  name: function-runner
+  namespace: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|porch-system|function-runner'
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: function-runner
+  template:
+    metadata:
+      labels:
+        app: function-runner
+    spec:
+      serviceAccountName: porch-fn-runner
+      containers:
+        - name: function-runner
+          image: nephio/porch-function-runner:v0.0.18
+          imagePullPolicy: IfNotPresent
+          command:
+            - /server
+            - --config=/config.yaml
+            - --functions=/functions
+            - --pod-namespace=porch-fn-system
+          env:
+            - name: WRAPPER_SERVER_IMAGE
+              value: nephio/porch-wrapper-server:v0.0.18
+          ports:
+            - containerPort: 9445
+          # Add grpc readiness probe to ensure the cache is ready
+          readinessProbe:
+            exec:
+              command:
+                - /grpc-health-probe
+                - -addr
+                - localhost:9445
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 125m
+          volumeMounts:
+            - mountPath: /pod-cache-config
+              name: pod-cache-config-volume
+      volumes:
+        - name: pod-cache-config-volume
+          configMap:
+            name: pod-cache-config
+---
+apiVersion: v1
+kind: Service
+metadata: # kpt-merge: porch-system/function-runner
+  name: function-runner
+  namespace: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|porch-system|function-runner'
+spec:
+  selector:
+    app: function-runner
+  ports:
+    - port: 9445
+      protocol: TCP
+      targetPort: 9445
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: porch-system/pod-cache-config
+  name: pod-cache-config
+  namespace: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|porch-system|pod-cache-config'
+data:
+  pod-cache-config.yaml: |
+    gcr.io/kpt-fn/apply-replacements:v0.1.1: 30m
+    gcr.io/kpt-fn/apply-setters:v0.2.0: 30m
+    gcr.io/kpt-fn/create-setters:v0.1.0: 30m
+    gcr.io/kpt-fn/ensure-name-substring:v0.2.0: 30m
+    gcr.io/kpt-fn/gatekeeper:v0.2.1: 30m
+    gcr.io/kpt-fn/kubeval:v0.2.0: 30m
+    gcr.io/kpt-fn/search-replace:v0.2.0: 30m
+    gcr.io/kpt-fn/set-annotations:v0.1.4: 30m
+    gcr.io/kpt-fn/set-enforcement-action:v0.1.0: 30m
+    gcr.io/kpt-fn/set-image:v0.1.1: 30m
+    gcr.io/kpt-fn/set-labels:v0.1.5: 30m
+    gcr.io/kpt-fn/set-namespace:v0.4.1: 30m
+    gcr.io/kpt-fn/starlark:v0.4.3: 30m
+    gcr.io/kpt-fn/upsert-resource:v0.2.0: 30m
+    gcr.io/kpt-fn/enable-gcp-services:v0.1.0: 30m
+    gcr.io/kpt-fn/export-terraform:v0.1.0: 30m
+    gcr.io/kpt-fn/generate-folders:v0.1.1: 30m
+    gcr.io/kpt-fn/remove-local-config-resources:v0.1.0: 30m
+    gcr.io/kpt-fn/set-project-id:v0.2.0: 30m

--- a/nephio-r1-base/porch/3-porch-server.yaml
+++ b/nephio-r1-base/porch/3-porch-server.yaml
@@ -1,0 +1,91 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ServiceAccount
+apiVersion: v1
+metadata: # kpt-merge: porch-system/porch-server
+  name: porch-server
+  namespace: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|porch-system|porch-server'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: porch-system/porch-server
+  name: porch-server
+  namespace: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|porch-system|porch-server'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: porch-server
+  template:
+    metadata:
+      labels:
+        app: porch-server
+    spec:
+      serviceAccountName: porch-server
+      volumes:
+        - name: cache-volume
+          emptyDir: {}
+        - name: webhook-certs
+          emptyDir: {}
+      containers:
+        - name: porch-server
+          # Update image to the image of your porch apiserver build.
+          image: nephio/porch-server:v0.0.18
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 250m
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /cache
+              name: cache-volume
+            - mountPath: /etc/webhook/certs
+              name: webhook-certs
+          env:
+            # Uncomment to enable trace-reporting to jaeger
+            #- name: OTEL
+            #  value: otel://jaeger-oltp:4317
+            - name: OTEL_SERVICE_NAME
+              value: porch-server
+            - name: CERT_STORAGE_DIR
+              value: /etc/webhook/certs
+          args:
+            - --function-runner=function-runner:9445
+            - --cache-directory=/cache
+---
+apiVersion: v1
+kind: Service
+metadata: # kpt-merge: porch-system/api
+  name: api
+  namespace: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|porch-system|api'
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 443
+      name: api
+    - port: 8443
+      protocol: TCP
+      targetPort: 8443
+      name: webhooks
+  selector:
+    app: porch-server

--- a/nephio-r1-base/porch/4-apiservice.yaml
+++ b/nephio-r1-base/porch/4-apiservice.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata: # kpt-merge: /v1alpha1.porch.kpt.dev
+  name: v1alpha1.porch.kpt.dev
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiregistration.k8s.io|APIService|default|v1alpha1.porch.kpt.dev'
+spec:
+  insecureSkipTLSVerify: true
+  group: porch.kpt.dev
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: api
+    namespace: porch-system
+  version: v1alpha1

--- a/nephio-r1-base/porch/5-rbac.yaml
+++ b/nephio-r1-base/porch/5-rbac.yaml
@@ -1,0 +1,138 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata: # kpt-merge: /aggregated-apiserver-clusterrole
+  name: aggregated-apiserver-clusterrole
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|aggregated-apiserver-clusterrole'
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - porch.kpt.dev
+    resources:
+      - functions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - config.porch.kpt.dev
+    resources:
+      - repositories
+      - repositories/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - porch.kpt.dev
+    resources:
+      - packagerevisions
+      - packagerevisions/status
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - config.porch.kpt.dev
+    resources:
+      - packagerevs
+      - packagerevs/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  # Needed for priority and fairness
+  - apiGroups:
+      - flowcontrol.apiserver.k8s.io
+    resources:
+      - flowschemas
+      - prioritylevelconfigurations
+    verbs:
+      - get
+      - watch
+      - list
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata: # kpt-merge: porch-system/aggregated-apiserver-role
+  name: aggregated-apiserver-role
+  namespace: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|porch-system|aggregated-apiserver-role'
+rules:
+  # Needed for workload identity
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata: # kpt-merge: porch-fn-system/porch-function-executor
+  name: porch-function-executor
+  namespace: porch-fn-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|porch-fn-system|porch-function-executor'
+rules:
+  # Needed to launch / read function executor pods
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - patch
+      - get
+      - watch
+      - list

--- a/nephio-r1-base/porch/6-rbac-bind.yaml
+++ b/nephio-r1-base/porch/6-rbac-bind.yaml
@@ -1,0 +1,59 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /sample-apiserver-clusterrolebinding
+  name: sample-apiserver-clusterrolebinding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|sample-apiserver-clusterrolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: aggregated-apiserver-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: porch-server
+    namespace: porch-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: porch-system/sample-apiserver-rolebinding
+  name: sample-apiserver-rolebinding
+  namespace: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|porch-system|sample-apiserver-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aggregated-apiserver-role
+subjects:
+  - kind: ServiceAccount
+    name: porch-server
+    namespace: porch-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: porch-fn-system/porch-function-executor
+  name: porch-function-executor
+  namespace: porch-fn-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|porch-fn-system|porch-function-executor'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: porch-function-executor
+subjects:
+  - kind: ServiceAccount
+    name: porch-fn-runner
+    namespace: porch-system

--- a/nephio-r1-base/porch/7-auth-reader.yaml
+++ b/nephio-r1-base/porch/7-auth-reader.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: kube-system/porch-auth-reader
+  name: porch-auth-reader
+  namespace: kube-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|kube-system|porch-auth-reader'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: porch-server
+  namespace: porch-system

--- a/nephio-r1-base/porch/8-auth-delegator.yaml
+++ b/nephio-r1-base/porch/8-auth-delegator.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /porch:system:auth-delegator
+  name: porch:system:auth-delegator
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|porch:system:auth-delegator'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: porch-server
+  namespace: porch-system

--- a/nephio-r1-base/porch/9-controllers.yaml
+++ b/nephio-r1-base/porch/9-controllers.yaml
@@ -1,0 +1,52 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ServiceAccount
+apiVersion: v1
+metadata: # kpt-merge: porch-system/porch-controllers
+  name: porch-controllers
+  namespace: porch-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|porch-system|porch-controllers'
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: porch-system/porch-controllers
+  name: porch-controllers
+  namespace: porch-system
+  labels:
+    k8s-app: porch-controllers
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|porch-system|porch-controllers'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: porch-controllers
+  template:
+    metadata:
+      labels:
+        k8s-app: porch-controllers
+    spec:
+      serviceAccountName: porch-controllers
+      containers:
+      - name: porch-controllers
+        # Update to the image of your porch-controllers build.
+        image: nephio/porch-controllers:v0.0.18
+        # Note: only the existence of the variable matters for enabling the reconciler
+        # So, be sure to remove the var not just change the value to false
+        env:
+        - name: ENABLE_PACKAGEVARIANTSETS
+          value: "true"
+        - name: ENABLE_PACKAGEVARIANTS
+          value: "true"

--- a/nephio-r1-base/porch/9-porch-controller-clusterrole.yaml
+++ b/nephio-r1-base/porch/9-porch-controller-clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /porch-controllers
+  creationTimestamp: null
+  name: porch-controllers
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|porch-controllers'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/nephio-r1-base/porch/9-porch-controller-packagevariants-clusterrole.yaml
+++ b/nephio-r1-base/porch/9-porch-controller-packagevariants-clusterrole.yaml
@@ -1,0 +1,58 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /porch-controllers-packagevariants
+  creationTimestamp: null
+  name: porch-controllers-packagevariants
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|porch-controllers-packagevariants'
+rules:
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariants
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariants/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariants/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - porch.kpt.dev
+  resources:
+  - packagerevisionresources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - porch.kpt.dev
+  resources:
+  - packagerevisions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/nephio-r1-base/porch/9-porch-controller-packagevariants-clusterrolebinding.yaml
+++ b/nephio-r1-base/porch/9-porch-controller-packagevariants-clusterrolebinding.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /porch-system:porch-controllers-packagevariants
+  name: porch-system:porch-controllers-packagevariants
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|porch-system:porch-controllers-packagevariants'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: porch-controllers-packagevariants
+subjects:
+- kind: ServiceAccount
+  name: porch-controllers
+  namespace: porch-system

--- a/nephio-r1-base/porch/9-porch-controller-packagevariantsets-clusterrole.yaml
+++ b/nephio-r1-base/porch/9-porch-controller-packagevariantsets-clusterrole.yaml
@@ -1,0 +1,52 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /porch-controllers-packagevariantsets
+  creationTimestamp: null
+  name: porch-controllers-packagevariantsets
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|porch-controllers-packagevariantsets'
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - list
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariants
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariantsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariantsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - packagevariantsets/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/nephio-r1-base/porch/9-porch-controller-packagevariantsets-clusterrolebinding.yaml
+++ b/nephio-r1-base/porch/9-porch-controller-packagevariantsets-clusterrolebinding.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /porch-system:porch-controllers-packagevariantsets
+  name: porch-system:porch-controllers-packagevariantsets
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|porch-system:porch-controllers-packagevariantsets'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: porch-controllers-packagevariantsets
+subjects:
+- kind: ServiceAccount
+  name: porch-controllers
+  namespace: porch-system

--- a/nephio-r1-base/porch/Kptfile
+++ b/nephio-r1-base/porch/Kptfile
@@ -1,0 +1,20 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: porch
+upstream:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /porch-dev
+    ref: porch-dev/v1
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /porch-dev
+    ref: porch-dev/v1
+    commit: 9f7db663456b7c9c34aa27f05e1034155ada3d93
+info:
+  description: porch dev package

--- a/nephio-r1-sandbox/Kptfile
+++ b/nephio-r1-sandbox/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: nephio-r1-sandbox
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: Packages for the Nephio management cluster sandbox environment

--- a/nephio-r1-sandbox/README.md
+++ b/nephio-r1-sandbox/README.md
@@ -1,0 +1,17 @@
+# nephio-r1-sandbox
+
+## Description
+Packages for the Nephio management cluster sandbox environment
+
+These should be applied to the Nephio management cluster after the
+nephio-r1-base packages. These are not part of the base Nephio system, but
+instead are extra components used for the demonstration sandbox environment. In
+particular, this includes:
+
+- Cert Manager
+- Cluster API
+- Cluster API Docker Infrastructure
+- Cluster API KinD Machine Templates
+- Resource Backend for IPAM and VLAN Allocation
+- Metal LB (not yet)
+- CoreDNS Instance for External Service DNS (not yet)

--- a/nephio-r1-sandbox/cert-manager/Kptfile
+++ b/nephio-r1-sandbox/cert-manager/Kptfile
@@ -1,0 +1,22 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: cert-manager
+  annotations:
+    config.kubernetes.io/local-config: "true"
+upstream:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /cert-manager
+    ref: cert-manager/v1
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /cert-manager
+    ref: cert-manager/v1
+    commit: 3c2fc2a655f0362fa26ed1fa179f01d6bb1dd84d
+info:
+  description: certificate manager package to deploy cert-manager

--- a/nephio-r1-sandbox/cert-manager/README.md
+++ b/nephio-r1-sandbox/cert-manager/README.md
@@ -1,0 +1,6 @@
+# cert-manager
+
+## Description
+
+certificate manager package to deploy cert-manager
+

--- a/nephio-r1-sandbox/cert-manager/cert-manager.yaml
+++ b/nephio-r1-sandbox/cert-manager/cert-manager.yaml
@@ -1,0 +1,5618 @@
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /cert-manager
+  name: cert-manager
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|cert-manager'
+---
+# Source: cert-manager/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /certificaterequests.cert-manager.io
+  name: certificaterequests.cert-manager.io
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|certificaterequests.cert-manager.io'
+spec:
+  group: cert-manager.io
+  names:
+    kind: CertificateRequest
+    listKind: CertificateRequestList
+    plural: certificaterequests
+    shortNames:
+      - cr
+      - crs
+    singular: certificaterequest
+    categories:
+      - cert-manager
+  scope: Namespaced
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Approved")].status
+          name: Approved
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Denied")].status
+          name: Denied
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          type: string
+        - jsonPath: .spec.username
+          name: Requestor
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a one-shot resource, meaning it represents a single point in time request for a certificate and cannot be re-used."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the CertificateRequest resource.
+              type: object
+              required:
+                - issuerRef
+                - request
+              properties:
+                duration:
+                  description: The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types.
+                  type: string
+                extra:
+                  description: Extra contains extra attributes of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.
+                  type: object
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+                groups:
+                  description: Groups contains group membership of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.
+                  type: array
+                  items:
+                    type: string
+                  x-kubernetes-list-type: atomic
+                isCA:
+                  description: IsCA will request to mark the certificate as valid for certificate signing when submitting to the issuer. This will automatically add the `cert sign` usage to the list of `usages`.
+                  type: boolean
+                issuerRef:
+                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to `cert-manager.io` if empty.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                request:
+                  description: The PEM-encoded x509 certificate signing request to be submitted to the CA for signing.
+                  type: string
+                  format: byte
+                uid:
+                  description: UID contains the uid of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.
+                  type: string
+                usages:
+                  description: Usages is the set of x509 usages that are requested for the certificate. If usages are set they SHOULD be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.
+                  type: array
+                  items:
+                    description: "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 \n Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\""
+                    type: string
+                    enum:
+                      - signing
+                      - digital signature
+                      - content commitment
+                      - key encipherment
+                      - key agreement
+                      - data encipherment
+                      - cert sign
+                      - crl sign
+                      - encipher only
+                      - decipher only
+                      - any
+                      - server auth
+                      - client auth
+                      - code signing
+                      - email protection
+                      - s/mime
+                      - ipsec end system
+                      - ipsec tunnel
+                      - ipsec user
+                      - timestamping
+                      - ocsp signing
+                      - microsoft sgc
+                      - netscape sgc
+                username:
+                  description: Username contains the name of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.
+                  type: string
+            status:
+              description: Status of the CertificateRequest. This is set and managed automatically.
+              type: object
+              properties:
+                ca:
+                  description: The PEM encoded x509 certificate of the signer, also known as the CA (Certificate Authority). This is set on a best-effort basis by different issuers. If not set, the CA is assumed to be unknown/not available.
+                  type: string
+                  format: byte
+                certificate:
+                  description: The PEM encoded x509 certificate resulting from the certificate signing request. If not set, the CertificateRequest has either not been completed or has failed. More information on failure can be found by checking the `conditions` field.
+                  type: string
+                  format: byte
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready` and `InvalidRequest`.
+                  type: array
+                  items:
+                    description: CertificateRequestCondition contains condition information for a CertificateRequest.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`, `InvalidRequest`, `Approved`, `Denied`).
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                failureTime:
+                  description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+      served: true
+      storage: true
+---
+# Source: cert-manager/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /certificates.cert-manager.io
+  name: certificates.cert-manager.io
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|certificates.cert-manager.io'
+spec:
+  group: cert-manager.io
+  names:
+    kind: Certificate
+    listKind: CertificateList
+    plural: certificates
+    shortNames:
+      - cert
+      - certs
+    singular: certificate
+    categories:
+      - cert-manager
+  scope: Namespaced
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.secretName
+          name: Secret
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: "A Certificate resource should be created to ensure an up to date and signed x509 certificate is stored in the Kubernetes Secret resource named in `spec.secretName`. \n The stored certificate will be renewed before it expires (as configured by `spec.renewBefore`)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the Certificate resource.
+              type: object
+              required:
+                - issuerRef
+                - secretName
+              properties:
+                additionalOutputFormats:
+                  description: AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option on both the controller and webhook components.
+                  type: array
+                  items:
+                    description: CertificateAdditionalOutputFormat defines an additional output format of a Certificate resource. These contain supplementary data formats of the signed certificate chain and paired private key.
+                    type: object
+                    required:
+                      - type
+                    properties:
+                      type:
+                        description: Type is the name of the format type that should be written to the Certificate's target Secret.
+                        type: string
+                        enum:
+                          - DER
+                          - CombinedPEM
+                commonName:
+                  description: 'CommonName is a common name to be used on the Certificate. The CommonName should have a length of 64 characters or fewer to avoid generating invalid CSRs. This value is ignored by TLS clients when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                  type: string
+                dnsNames:
+                  description: DNSNames is a list of DNS subjectAltNames to be set on the Certificate.
+                  type: array
+                  items:
+                    type: string
+                duration:
+                  description: The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types. If unset this defaults to 90 days. Certificate will be renewed either 2/3 through its duration or `renewBefore` period before its expiry, whichever is later. Minimum accepted duration is 1 hour. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                  type: string
+                emailAddresses:
+                  description: EmailAddresses is a list of email subjectAltNames to be set on the Certificate.
+                  type: array
+                  items:
+                    type: string
+                encodeUsagesInRequest:
+                  description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
+                  type: boolean
+                ipAddresses:
+                  description: IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.
+                  type: array
+                  items:
+                    type: string
+                isCA:
+                  description: IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.
+                  type: boolean
+                issuerRef:
+                  description: IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                keystores:
+                  description: Keystores configures additional keystore output formats stored in the `secretName` Secret resource.
+                  type: object
+                  properties:
+                    jks:
+                      description: JKS configures options for storing a JKS keystore in the `spec.secretName` Secret resource.
+                      type: object
+                      required:
+                        - create
+                        - passwordSecretRef
+                      properties:
+                        create:
+                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
+                          type: boolean
+                        passwordSecretRef:
+                          description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    pkcs12:
+                      description: PKCS12 configures options for storing a PKCS12 keystore in the `spec.secretName` Secret resource.
+                      type: object
+                      required:
+                        - create
+                        - passwordSecretRef
+                      properties:
+                        create:
+                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will be updated immediately. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
+                          type: boolean
+                        passwordSecretRef:
+                          description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                literalSubject:
+                  description: LiteralSubject is an LDAP formatted string that represents the [X.509 Subject field](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6). Use this *instead* of the Subject field if you need to ensure the correct ordering of the RDN sequence, such as when issuing certs for LDAP authentication. See https://github.com/cert-manager/cert-manager/issues/3203, https://github.com/cert-manager/cert-manager/issues/4424. This field is alpha level and is only supported by cert-manager installations where LiteralCertificateSubject feature gate is enabled on both cert-manager controller and webhook.
+                  type: string
+                privateKey:
+                  description: Options to control private keys used for the Certificate.
+                  type: object
+                  properties:
+                    algorithm:
+                      description: Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `RSA`,`Ed25519` or `ECDSA` If `algorithm` is specified and `size` is not provided, key size of 256 will be used for `ECDSA` key algorithm and key size of 2048 will be used for `RSA` key algorithm. key size is ignored when using the `Ed25519` key algorithm.
+                      type: string
+                      enum:
+                        - RSA
+                        - ECDSA
+                        - Ed25519
+                    encoding:
+                      description: The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and PKCS#8, respectively. Defaults to `PKCS1` if not specified.
+                      type: string
+                      enum:
+                        - PKCS1
+                        - PKCS8
+                    rotationPolicy:
+                      description: RotationPolicy controls how private keys should be regenerated when a re-issuance is being processed. If set to Never, a private key will only be generated if one does not already exist in the target `spec.secretName`. If one does exists but it does not have the correct algorithm or size, a warning will be raised to await user intervention. If set to Always, a private key matching the specified requirements will be generated whenever a re-issuance occurs. Default is 'Never' for backward compatibility.
+                      type: string
+                      enum:
+                        - Never
+                        - Always
+                    size:
+                      description: Size is the key bit size of the corresponding private key for this certificate. If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. If `algorithm` is set to `Ed25519`, Size is ignored. No other values are allowed.
+                      type: integer
+                renewBefore:
+                  description: How long before the currently issued certificate's expiry cert-manager should renew the certificate. The default is 2/3 of the issued certificate's duration. Minimum accepted value is 5 minutes. Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                  type: string
+                revisionHistoryLimit:
+                  description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
+                  type: integer
+                  format: int32
+                secretName:
+                  description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
+                  type: string
+                secretTemplate:
+                  description: SecretTemplate defines annotations and labels to be copied to the Certificate's Secret. Labels and annotations on the Secret will be changed as they appear on the SecretTemplate when added or removed. SecretTemplate annotations are added in conjunction with, and cannot overwrite, the base set of annotations cert-manager sets on the Certificate's Secret.
+                  type: object
+                  properties:
+                    annotations:
+                      description: Annotations is a key value map to be copied to the target Kubernetes Secret.
+                      type: object
+                      additionalProperties:
+                        type: string
+                    labels:
+                      description: Labels is a key value map to be copied to the target Kubernetes Secret.
+                      type: object
+                      additionalProperties:
+                        type: string
+                subject:
+                  description: Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
+                  type: object
+                  properties:
+                    countries:
+                      description: Countries to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    localities:
+                      description: Cities to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    organizationalUnits:
+                      description: Organizational Units to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    organizations:
+                      description: Organizations to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    postalCodes:
+                      description: Postal codes to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    provinces:
+                      description: State/Provinces to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                    serialNumber:
+                      description: Serial number to be used on the Certificate.
+                      type: string
+                    streetAddresses:
+                      description: Street addresses to be used on the Certificate.
+                      type: array
+                      items:
+                        type: string
+                uris:
+                  description: URIs is a list of URI subjectAltNames to be set on the Certificate.
+                  type: array
+                  items:
+                    type: string
+                usages:
+                  description: Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.
+                  type: array
+                  items:
+                    description: "KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12 \n Valid KeyUsage values are as follows: \"signing\", \"digital signature\", \"content commitment\", \"key encipherment\", \"key agreement\", \"data encipherment\", \"cert sign\", \"crl sign\", \"encipher only\", \"decipher only\", \"any\", \"server auth\", \"client auth\", \"code signing\", \"email protection\", \"s/mime\", \"ipsec end system\", \"ipsec tunnel\", \"ipsec user\", \"timestamping\", \"ocsp signing\", \"microsoft sgc\", \"netscape sgc\""
+                    type: string
+                    enum:
+                      - signing
+                      - digital signature
+                      - content commitment
+                      - key encipherment
+                      - key agreement
+                      - data encipherment
+                      - cert sign
+                      - crl sign
+                      - encipher only
+                      - decipher only
+                      - any
+                      - server auth
+                      - client auth
+                      - code signing
+                      - email protection
+                      - s/mime
+                      - ipsec end system
+                      - ipsec tunnel
+                      - ipsec user
+                      - timestamping
+                      - ocsp signing
+                      - microsoft sgc
+                      - netscape sgc
+            status:
+              description: Status of the Certificate. This is set and managed automatically.
+              type: object
+              properties:
+                conditions:
+                  description: List of status conditions to indicate the status of certificates. Known condition types are `Ready` and `Issuing`.
+                  type: array
+                  items:
+                    description: CertificateCondition contains condition information for an Certificate.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`, `Issuing`).
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                failedIssuanceAttempts:
+                  description: The number of continuous failed issuance attempts up till now. This field gets removed (if set) on a successful issuance and gets set to 1 if unset and an issuance has failed. If an issuance has failed, the delay till the next issuance will be calculated using formula time.Hour * 2 ^ (failedIssuanceAttempts - 1).
+                  type: integer
+                lastFailureTime:
+                  description: LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.
+                  type: string
+                  format: date-time
+                nextPrivateKeySecretName:
+                  description: The name of the Secret resource containing the private key to be used for the next certificate iteration. The keymanager controller will automatically set this field if the `Issuing` condition is set to `True`. It will automatically unset this field when the Issuing condition is not set or False.
+                  type: string
+                notAfter:
+                  description: The expiration time of the certificate stored in the secret named by this resource in `spec.secretName`.
+                  type: string
+                  format: date-time
+                notBefore:
+                  description: The time after which the certificate stored in the secret named by this resource in spec.secretName is valid.
+                  type: string
+                  format: date-time
+                renewalTime:
+                  description: RenewalTime is the time at which the certificate will be next renewed. If not set, no upcoming renewal is scheduled.
+                  type: string
+                  format: date-time
+                revision:
+                  description: "The current 'revision' of the certificate as issued. \n When a CertificateRequest resource is created, it will have the `cert-manager.io/certificate-revision` set to one greater than the current value of this field. \n Upon issuance, this field will be set to the value of the annotation on the CertificateRequest resource used to issue the certificate. \n Persisting the value on the CertificateRequest resource allows the certificates controller to know whether a request is part of an old issuance or if it is part of the ongoing revision's issuance by checking if the revision value in the annotation is greater than this field."
+                  type: integer
+      served: true
+      storage: true
+---
+# Source: cert-manager/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /challenges.acme.cert-manager.io
+  name: challenges.acme.cert-manager.io
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|challenges.acme.cert-manager.io'
+spec:
+  group: acme.cert-manager.io
+  names:
+    kind: Challenge
+    listKind: ChallengeList
+    plural: challenges
+    singular: challenge
+    categories:
+      - cert-manager
+      - cert-manager-acme
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.dnsName
+          name: Domain
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Challenge is a type to represent a Challenge request with an ACME server
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - authorizationURL
+                - dnsName
+                - issuerRef
+                - key
+                - solver
+                - token
+                - type
+                - url
+              properties:
+                authorizationURL:
+                  description: The URL to the ACME Authorization resource that this challenge is a part of.
+                  type: string
+                dnsName:
+                  description: dnsName is the identifier that this challenge is for, e.g. example.com. If the requested DNSName is a 'wildcard', this field MUST be set to the non-wildcard domain, e.g. for `*.example.com`, it must be `example.com`.
+                  type: string
+                issuerRef:
+                  description: References a properly configured ACME-type Issuer which should be used to create this Challenge. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Challenge will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                key:
+                  description: 'The ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key from acme server for challenge>`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key from acme server for challenge>` text that must be set as the TXT record content.'
+                  type: string
+                solver:
+                  description: Contains the domain solving configuration that should be used to solve this challenge resource.
+                  type: object
+                  properties:
+                    dns01:
+                      description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                      type: object
+                      properties:
+                        acmeDNS:
+                          description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accountSecretRef
+                            - host
+                          properties:
+                            accountSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            host:
+                              type: string
+                        akamai:
+                          description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                          properties:
+                            accessTokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            clientSecretSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            clientTokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceConsumerDomain:
+                              type: string
+                        azureDNS:
+                          description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - resourceGroupName
+                            - subscriptionID
+                          properties:
+                            clientID:
+                              description: if both this and ClientSecret are left unset MSI will be used
+                              type: string
+                            clientSecretSecretRef:
+                              description: if both this and ClientID are left unset MSI will be used
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            environment:
+                              description: name of the Azure environment (default AzurePublicCloud)
+                              type: string
+                              enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                            hostedZoneName:
+                              description: name of the DNS zone that should be used
+                              type: string
+                            managedIdentity:
+                              description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                              type: object
+                              properties:
+                                clientID:
+                                  description: client ID of the managed identity, can not be used at the same time as resourceID
+                                  type: string
+                                resourceID:
+                                  description: resource ID of the managed identity, can not be used at the same time as clientID
+                                  type: string
+                            resourceGroupName:
+                              description: resource group the DNS zone is located in
+                              type: string
+                            subscriptionID:
+                              description: ID of the Azure subscription
+                              type: string
+                            tenantID:
+                              description: when specifying ClientID and ClientSecret then this field is also needed
+                              type: string
+                        cloudDNS:
+                          description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - project
+                          properties:
+                            hostedZoneName:
+                              description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                              type: string
+                            project:
+                              type: string
+                            serviceAccountSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        cloudflare:
+                          description: Use the Cloudflare API to manage DNS01 challenge records.
+                          type: object
+                          properties:
+                            apiKeySecretRef:
+                              description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            apiTokenSecretRef:
+                              description: API token used to authenticate with Cloudflare.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            email:
+                              description: Email of the account, only required when using API key based authentication.
+                              type: string
+                        cnameStrategy:
+                          description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                          type: string
+                          enum:
+                            - None
+                            - Follow
+                        digitalocean:
+                          description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - tokenSecretRef
+                          properties:
+                            tokenSecretRef:
+                              description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        rfc2136:
+                          description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - nameserver
+                          properties:
+                            nameserver:
+                              description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                              type: string
+                            tsigAlgorithm:
+                              description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                              type: string
+                            tsigKeyName:
+                              description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                              type: string
+                            tsigSecretSecretRef:
+                              description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        route53:
+                          description: Use the AWS Route53 API to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - region
+                          properties:
+                            accessKeyID:
+                              description: 'The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                              type: string
+                            accessKeyIDSecretRef:
+                              description: 'The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            hostedZoneID:
+                              description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                              type: string
+                            region:
+                              description: Always set the region when using AccessKeyID and SecretAccessKey
+                              type: string
+                            role:
+                              description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                              type: string
+                            secretAccessKeySecretRef:
+                              description: 'The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        webhook:
+                          description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                          type: object
+                          required:
+                            - groupName
+                            - solverName
+                          properties:
+                            config:
+                              description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                              x-kubernetes-preserve-unknown-fields: true
+                            groupName:
+                              description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                              type: string
+                            solverName:
+                              description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                              type: string
+                    http01:
+                      description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                      type: object
+                      properties:
+                        gatewayHTTPRoute:
+                          description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                          type: object
+                          properties:
+                            labels:
+                              description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
+                              type: object
+                              additionalProperties:
+                                type: string
+                            parentRefs:
+                              description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways'
+                              type: array
+                              items:
+                                description: "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid."
+                                type: object
+                                required:
+                                  - name
+                                properties:
+                                  group:
+                                    description: "Group is the group of the referent. When unspecified, \"gateway.networking.k8s.io\" is inferred. To set the core API group (such as for a \"Service\" kind referent), Group must be explicitly set to \"\" (empty string). \n Support: Core"
+                                    type: string
+                                    default: gateway.networking.k8s.io
+                                    maxLength: 253
+                                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  kind:
+                                    description: "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Implementation-specific (Other Resources)"
+                                    type: string
+                                    default: Gateway
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  name:
+                                    description: "Name is the name of the referent. \n Support: Core"
+                                    type: string
+                                    maxLength: 253
+                                    minLength: 1
+                                  namespace:
+                                    description: "Namespace is the namespace of the referent. When unspecified, this refers to the local namespace of the Route. \n Note that there are specific rules for ParentRefs which cross namespace boundaries. Cross-namespace references are only valid if they are explicitly allowed by something in the namespace they are referring to. For example: Gateway has the AllowedRoutes field, and ReferenceGrant provides a generic way to enable any other kind of cross-namespace reference. \n Support: Core"
+                                    type: string
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  port:
+                                    description: "Port is the network port this Route targets. It can be interpreted differently based on the type of parent resource. \n When the parent resource is a Gateway, this targets all listeners listening on the specified port that also support this kind of Route(and select this Route). It's not recommended to set `Port` unless the networking behaviors specified in a Route must apply to a specific port as opposed to a listener(s) whose port(s) may be changed. When both Port and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support other parent resources. Implementations supporting other types of parent resources MUST clearly document how/if Port is interpreted. \n For the purpose of status, an attachment is considered successful as long as the parent resource accepts it partially. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Extended \n <gateway:experimental>"
+                                    type: integer
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                  sectionName:
+                                    description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name. When both Port (experimental) and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                                    type: string
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            serviceType:
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
+                              type: string
+                        ingress:
+                          description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                          type: object
+                          properties:
+                            class:
+                              description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                              type: string
+                            ingressTemplate:
+                              description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                            name:
+                              description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                              type: string
+                            podTemplate:
+                              description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                spec:
+                                  description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                  type: object
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      type: object
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                type: object
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                              type: object
+                                              required:
+                                                - nodeSelectorTerms
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  type: array
+                                                  items:
+                                                    description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                    x-kubernetes-map-type: atomic
+                                              x-kubernetes-map-type: atomic
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over a set of resources, in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaceSelector:
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over a set of resources, in this case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaceSelector:
+                                                        description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                    type: string
+                                    nodeSelector:
+                                      description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    priorityClassName:
+                                      description: If specified, the pod's priorityClassName.
+                                      type: string
+                                    serviceAccountName:
+                                      description: If specified, the pod's service account
+                                      type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      type: array
+                                      items:
+                                        description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                        type: object
+                                        properties:
+                                          effect:
+                                            description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                            type: integer
+                                            format: int64
+                                          value:
+                                            description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
+                              type: string
+                    selector:
+                      description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                      type: object
+                      properties:
+                        dnsNames:
+                          description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        dnsZones:
+                          description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        matchLabels:
+                          description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                          type: object
+                          additionalProperties:
+                            type: string
+                token:
+                  description: The ACME challenge token for this challenge. This is the raw value returned from the ACME server.
+                  type: string
+                type:
+                  description: The type of ACME challenge this resource represents. One of "HTTP-01" or "DNS-01".
+                  type: string
+                  enum:
+                    - HTTP-01
+                    - DNS-01
+                url:
+                  description: The URL of the ACME Challenge resource for this challenge. This can be used to lookup details about the status of this challenge.
+                  type: string
+                wildcard:
+                  description: wildcard will be true if this challenge is for a wildcard identifier, for example '*.example.com'.
+                  type: boolean
+            status:
+              type: object
+              properties:
+                presented:
+                  description: presented will be set to true if the challenge values for this challenge are currently 'presented'. This *does not* imply the self check is passing. Only that the values have been 'submitted' for the appropriate challenge mechanism (i.e. the DNS01 TXT record has been presented, or the HTTP01 configuration has been configured).
+                  type: boolean
+                processing:
+                  description: Used to denote whether this challenge should be processed or not. This field will only be set to true by the 'scheduling' component. It will only be set to false by the 'challenges' controller, after the challenge has reached a final state or timed out. If this field is set to false, the challenge controller will not take any more action.
+                  type: boolean
+                reason:
+                  description: Contains human readable information on why the Challenge is in the current state.
+                  type: string
+                state:
+                  description: Contains the current 'state' of the challenge. If not set, the state of the challenge is unknown.
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+# Source: cert-manager/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /clusterissuers.cert-manager.io
+  name: clusterissuers.cert-manager.io
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|clusterissuers.cert-manager.io'
+spec:
+  group: cert-manager.io
+  names:
+    kind: ClusterIssuer
+    listKind: ClusterIssuerList
+    plural: clusterissuers
+    singular: clusterissuer
+    categories:
+      - cert-manager
+  scope: Cluster
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: A ClusterIssuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is similar to an Issuer, however it is cluster-scoped and therefore can be referenced by resources that exist in *any* namespace, not just the same namespace as the referent.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the ClusterIssuer resource.
+              type: object
+              properties:
+                acme:
+                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    caBundle:
+                      description: Base64-encoded bundle of PEM CAs which can be used to validate the certificate chain presented by the ACME server. Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various kinds of security vulnerabilities. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
+                    email:
+                      description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: 'Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.'
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    server:
+                      description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                      type: string
+                    skipTLSVerify:
+                      description: 'INSECURE: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have the TLS certificate chain validated. Mutually exclusive with CABundle; prefer using CABundle to prevent various kinds of security vulnerabilities. Only enable this option in development environments. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection. Defaults to false.'
+                      type: boolean
+                    solvers:
+                      description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                      type: array
+                      items:
+                        description: An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmeDNS:
+                                description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azureDNS:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    description: name of the DNS zone that should be used
+                                    type: string
+                                  managedIdentity:
+                                    description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: resource ID of the managed identity, can not be used at the same time as clientID
+                                        type: string
+                                  resourceGroupName:
+                                    description: resource group the DNS zone is located in
+                                    type: string
+                                  subscriptionID:
+                                    description: ID of the Azure subscription
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                              cloudDNS:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              rfc2136:
+                                description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  accessKeyIDSecretRef:
+                                    description: 'The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: 'The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              webhook:
+                                description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  parentRefs:
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways'
+                                    type: array
+                                    items:
+                                      description: "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid."
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        group:
+                                          description: "Group is the group of the referent. When unspecified, \"gateway.networking.k8s.io\" is inferred. To set the core API group (such as for a \"Service\" kind referent), Group must be explicitly set to \"\" (empty string). \n Support: Core"
+                                          type: string
+                                          default: gateway.networking.k8s.io
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        kind:
+                                          description: "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Implementation-specific (Other Resources)"
+                                          type: string
+                                          default: Gateway
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                        name:
+                                          description: "Name is the name of the referent. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                        namespace:
+                                          description: "Namespace is the namespace of the referent. When unspecified, this refers to the local namespace of the Route. \n Note that there are specific rules for ParentRefs which cross namespace boundaries. Cross-namespace references are only valid if they are explicitly allowed by something in the namespace they are referring to. For example: Gateway has the AllowedRoutes field, and ReferenceGrant provides a generic way to enable any other kind of cross-namespace reference. \n Support: Core"
+                                          type: string
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        port:
+                                          description: "Port is the network port this Route targets. It can be interpreted differently based on the type of parent resource. \n When the parent resource is a Gateway, this targets all listeners listening on the specified port that also support this kind of Route(and select this Route). It's not recommended to set `Port` unless the networking behaviors specified in a Route must apply to a specific port as opposed to a listener(s) whose port(s) may be changed. When both Port and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support other parent resources. Implementations supporting other types of parent resources MUST clearly document how/if Port is interpreted. \n For the purpose of status, an attachment is considered successful as long as the parent resource accepts it partially. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Extended \n <gateway:experimental>"
+                                          type: integer
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                        sectionName:
+                                          description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name. When both Port (experimental) and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                          x-kubernetes-map-type: atomic
+                                                    x-kubernetes-map-type: atomic
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates issued by this Issuer.
+                      type: string
+                selfSigned:
+                  description: SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              type: string
+                            roleId:
+                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        kubernetes:
+                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    caBundle:
+                      description: Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by Vault. Only used if using HTTPS to connect to Vault and ignored for HTTP connections. Mutually exclusive with CABundleSecretRef. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    caBundleSecretRef:
+                      description: Reference to a Secret containing a bundle of PEM-encoded CAs to use when verifying the certificate chain presented by Vault when using HTTPS. Mutually exclusive with CABundle. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection. If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    namespace:
+                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      type: string
+                    path:
+                      description: 'Path is the mount path of the Vault PKI backend''s `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud. Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP. If undefined, the certificate bundle in the cert-manager controller container is used to validate the chain.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: 'URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.
+                      type: string
+            status:
+              description: Status of the ClusterIssuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+      served: true
+      storage: true
+---
+# Source: cert-manager/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /issuers.cert-manager.io
+  name: issuers.cert-manager.io
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|issuers.cert-manager.io'
+spec:
+  group: cert-manager.io
+  names:
+    kind: Issuer
+    listKind: IssuerList
+    plural: issuers
+    singular: issuer
+    categories:
+      - cert-manager
+  scope: Namespaced
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: An Issuer represents a certificate issuing authority which can be referenced as part of `issuerRef` fields. It is scoped to a single namespace and can therefore only be referenced by resources within the same namespace.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the Issuer resource.
+              type: object
+              properties:
+                acme:
+                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    caBundle:
+                      description: Base64-encoded bundle of PEM CAs which can be used to validate the certificate chain presented by the ACME server. Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various kinds of security vulnerabilities. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
+                    email:
+                      description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
+                      type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
+                      type: object
+                      required:
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: 'Deprecated: keyAlgorithm field exists for historical compatibility reasons and should not be used. The algorithm is now hardcoded to HS256 in golang/x/crypto/acme.'
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes Secret which holds the symmetric MAC key of the External Account Binding. The `key` is the index string that is paired with the key data in the Secret and should not be confused with the key data itself, or indeed with the External Account Binding keyID above. The secret key stored in the Secret **must** be un-padded, base64 URL encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
+                      type: string
+                      maxLength: 64
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    server:
+                      description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
+                      type: string
+                    skipTLSVerify:
+                      description: 'INSECURE: Enables or disables validation of the ACME server TLS certificate. If true, requests to the ACME server will not have the TLS certificate chain validated. Mutually exclusive with CABundle; prefer using CABundle to prevent various kinds of security vulnerabilities. Only enable this option in development environments. If CABundle and SkipTLSVerify are unset, the system certificate bundle inside the container is used to validate the TLS connection. Defaults to false.'
+                      type: boolean
+                    solvers:
+                      description: 'Solvers is a list of challenge solvers that will be used to solve ACME challenges for the matching domains. Solver configurations must be provided in order to obtain certificates from an ACME server. For more information, see: https://cert-manager.io/docs/configuration/acme/'
+                      type: array
+                      items:
+                        description: An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of. A selector may be provided to use different solving strategies for different DNS names. Only one of HTTP01 or DNS01 must be provided.
+                        type: object
+                        properties:
+                          dns01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
+                            type: object
+                            properties:
+                              acmeDNS:
+                                description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azureDNS:
+                                description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  environment:
+                                    description: name of the Azure environment (default AzurePublicCloud)
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    description: name of the DNS zone that should be used
+                                    type: string
+                                  managedIdentity:
+                                    description: managed identity configuration, can not be used at the same time as clientID, clientSecretSecretRef or tenantID
+                                    type: object
+                                    properties:
+                                      clientID:
+                                        description: client ID of the managed identity, can not be used at the same time as resourceID
+                                        type: string
+                                      resourceID:
+                                        description: resource ID of the managed identity, can not be used at the same time as clientID
+                                        type: string
+                                  resourceGroupName:
+                                    description: resource group the DNS zone is located in
+                                    type: string
+                                  subscriptionID:
+                                    description: ID of the Azure subscription
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                              cloudDNS:
+                                description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  hostedZoneName:
+                                    description: HostedZoneName is an optional field that tells cert-manager in which Cloud DNS zone the challenge record has to be created. If left empty cert-manager will automatically choose a zone.
+                                    type: string
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              cloudflare:
+                                description: Use the Cloudflare API to manage DNS01 challenge records.
+                                type: object
+                                properties:
+                                  apiKeySecretRef:
+                                    description: 'API key to use to authenticate with Cloudflare. Note: using an API token to authenticate is now the recommended method as it allows greater control of permissions.'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    description: API token used to authenticate with Cloudflare.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  email:
+                                    description: Email of the account, only required when using API key based authentication.
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    description: A reference to a specific 'key' within a Secret resource. In some instances, `key` is a required field.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              rfc2136:
+                                description: Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/) to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]) ; port is optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the DNS supporting RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined. Supported values are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS. If ``tsigSecretSecretRef`` is defined, this field is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the TSIG value. If ``tsigKeyName`` is defined, this field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              route53:
+                                description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication. Cannot be set when SecretAccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  accessKeyIDSecretRef:
+                                    description: 'The SecretAccessKey is used for authentication. If set, pull the AWS access key ID from a key within a Kubernetes Secret. Cannot be set when AccessKeyID is set. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: 'The SecretAccessKey is used for authentication. If neither the Access Key nor Key ID are set, we fall-back to using env vars, shared credentials file or AWS Instance metadata, see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                        type: string
+                                      name:
+                                        description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                              webhook:
+                                description: Configure an external webhook based DNS01 challenge solver to manage DNS01 challenge records.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should be passed to the webhook apiserver when challenges are processed. This can contain arbitrary JSON data. Secret values should not be specified in this stanza. If secret values are needed (e.g. credentials for a DNS service), you should use a SecretKeySelector to reference a Secret resource. For details on the schema of this field, consult the webhook provider implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used when POSTing ChallengePayload resources to the webhook apiserver. This should be the same as the GroupName specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined in the webhook provider implementation. This will typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: Configures cert-manager to attempt to complete authorizations by performing the HTTP01 challenge flow. It is not possible to obtain certificates for wildcard domain names (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                            type: object
+                            properties:
+                              gatewayHTTPRoute:
+                                description: The Gateway API is a sig-network community API that models service networking in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will create HTTPRoutes with the specified labels in the same namespace as the challenge. This solver is experimental, and fields / behaviour may change in the future.
+                                type: object
+                                properties:
+                                  labels:
+                                    description: Custom labels that will be applied to HTTPRoutes created by cert-manager while solving HTTP-01 challenges.
+                                    type: object
+                                    additionalProperties:
+                                      type: string
+                                  parentRefs:
+                                    description: 'When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute. cert-manager needs to know which parentRefs should be used when creating the HTTPRoute. Usually, the parentRef references a Gateway. See: https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways'
+                                    type: array
+                                    items:
+                                      description: "ParentReference identifies an API object (usually a Gateway) that can be considered a parent of this resource (usually a route). The only kind of parent resource with \"Core\" support is Gateway. This API may be extended in the future to support additional kinds of parent resources, such as HTTPRoute. \n The API object must be valid in the cluster; the Group and Kind must be registered in the cluster for this reference to be valid."
+                                      type: object
+                                      required:
+                                        - name
+                                      properties:
+                                        group:
+                                          description: "Group is the group of the referent. When unspecified, \"gateway.networking.k8s.io\" is inferred. To set the core API group (such as for a \"Service\" kind referent), Group must be explicitly set to \"\" (empty string). \n Support: Core"
+                                          type: string
+                                          default: gateway.networking.k8s.io
+                                          maxLength: 253
+                                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        kind:
+                                          description: "Kind is kind of the referent. \n Support: Core (Gateway) \n Support: Implementation-specific (Other Resources)"
+                                          type: string
+                                          default: Gateway
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                        name:
+                                          description: "Name is the name of the referent. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                        namespace:
+                                          description: "Namespace is the namespace of the referent. When unspecified, this refers to the local namespace of the Route. \n Note that there are specific rules for ParentRefs which cross namespace boundaries. Cross-namespace references are only valid if they are explicitly allowed by something in the namespace they are referring to. For example: Gateway has the AllowedRoutes field, and ReferenceGrant provides a generic way to enable any other kind of cross-namespace reference. \n Support: Core"
+                                          type: string
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        port:
+                                          description: "Port is the network port this Route targets. It can be interpreted differently based on the type of parent resource. \n When the parent resource is a Gateway, this targets all listeners listening on the specified port that also support this kind of Route(and select this Route). It's not recommended to set `Port` unless the networking behaviors specified in a Route must apply to a specific port as opposed to a listener(s) whose port(s) may be changed. When both Port and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support other parent resources. Implementations supporting other types of parent resources MUST clearly document how/if Port is interpreted. \n For the purpose of status, an attachment is considered successful as long as the parent resource accepts it partially. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Extended \n <gateway:experimental>"
+                                          type: integer
+                                          format: int32
+                                          maximum: 65535
+                                          minimum: 1
+                                        sectionName:
+                                          description: "SectionName is the name of a section within the target resource. In the following resources, SectionName is interpreted as the following: \n * Gateway: Listener Name. When both Port (experimental) and SectionName are specified, the name and port of the selected listener must match both specified values. \n Implementations MAY choose to support attaching Routes to other resources. If that is the case, they MUST clearly document how SectionName is interpreted. \n When unspecified (empty string), this will reference the entire resource. For the purpose of status, an attachment is considered successful if at least one section in the parent resource accepts it. For example, Gateway listeners can restrict which Routes can attach to them by Route kind, namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from the referencing Route, the Route MUST be considered successfully attached. If no Gateway listeners accept attachment from this Route, the Route MUST be considered detached from the Gateway. \n Support: Core"
+                                          type: string
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of 'class' or 'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure the ACME challenge solver ingress used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that should have ACME challenge solving routes inserted into it in order to solve HTTP01 challenges. This is typically used in conjunction with ingress controllers like ingress-gce, which maintains a 1:1 mapping between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure the ACME challenge solver pods used for HTTP01 challenges.
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod used to solve HTTP01 challenges. Only the 'labels' and 'annotations' fields may be set. If labels or annotations overlap with in-built values, the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the HTTP01 challenge solver pod. Only the 'priorityClassName', 'nodeSelector', 'affinity', 'serviceAccountName' and 'tolerations' fields are supported currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector term, associated with the corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        weight:
+                                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node selector requirements by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node selector requirements by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                          x-kubernetes-map-type: atomic
+                                                    x-kubernetes-map-type: atomic
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query over a set of resources, in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaceSelector:
+                                                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key is the label key that the selector applies to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                              x-kubernetes-map-type: atomic
+                                                            namespaces:
+                                                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over a set of resources, in this case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaceSelector:
+                                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                          x-kubernetes-map-type: atomic
+                                                        namespaces:
+                                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          priorityClassName:
+                                            description: If specified, the pod's priorityClassName.
+                                            type: string
+                                          serviceAccountName:
+                                            description: If specified, the pod's service account
+                                            type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be used to solve. If specified and a match is found, a dnsNames selector will take precedence over a dnsZones selector. If multiple solvers match with the same dnsNames value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be used to solve. The most specific DNS zone match specified here will take precedence over other DNS zone matches, so a solver specifying sys.example.com will be selected over one specifying example.com for the domain www.sys.example.com. If multiple solvers match with the same dnsZones value, the solver with the most matching labels in matchLabels will be selected. If neither has more matches, the solver defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the set of certificate's that this challenge solver will apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  description: CA configures this issuer to sign certificates using a signing CA keypair stored in a Secret resource. This is used to build internal PKIs that are managed by cert-manager.
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set, certificates will be issued without distribution points set.
+                      type: array
+                      items:
+                        type: string
+                    ocspServers:
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates issued by this Issuer.
+                      type: string
+                selfSigned:
+                  description: SelfSigned configures this issuer to 'self sign' certificates using the private key used to create the CertificateRequest object.
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate extension which identifies the location of the CRL from which the revocation of this certificate can be checked. If not set certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  description: Vault configures this issuer to sign certificates using a HashiCorp Vault PKI backend.
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Auth configures how cert-manager authenticates with the Vault server.
+                      type: object
+                      properties:
+                        appRole:
+                          description: AppRole authenticates with Vault using the App Role auth mechanism, with the role and secret stored in a Kubernetes Secret resource.
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: 'Path where the App Role authentication backend is mounted in Vault, e.g: "approle"'
+                              type: string
+                            roleId:
+                              description: RoleID configured in the App Role authentication backend when setting up the authentication backend in Vault.
+                              type: string
+                            secretRef:
+                              description: Reference to a key in a Secret that contains the App Role secret used to authenticate with Vault. The `key` field must be specified and denotes which entry within the Secret resource is used as the app role secret.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        kubernetes:
+                          description: Kubernetes authenticates with Vault by passing the ServiceAccount token stored in the named Secret resource to the Vault server.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role to assume. A Role binds a Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes ServiceAccount JWT used for authenticating with Vault. Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                                  type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                    caBundle:
+                      description: Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by Vault. Only used if using HTTPS to connect to Vault and ignored for HTTP connections. Mutually exclusive with CABundleSecretRef. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    caBundleSecretRef:
+                      description: Reference to a Secret containing a bundle of PEM-encoded CAs to use when verifying the certificate chain presented by Vault when using HTTPS. Mutually exclusive with CABundle. If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in the cert-manager controller container is used to validate the TLS connection. If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        key:
+                          description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                          type: string
+                        name:
+                          description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                    namespace:
+                      description: 'Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1" More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                      type: string
+                    path:
+                      description: 'Path is the mount path of the Vault PKI backend''s `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
+                      type: string
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                venafi:
+                  description: Venafi configures this issuer to sign certificates using a Venafi TPP or Venafi Cloud policy zone.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
+                              type: string
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud. Defaults to "https://api.venafi.cloud/v1".
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: Base64-encoded bundle of PEM CAs which will be used to validate the certificate chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP. If undefined, the certificate bundle in the cert-manager controller container is used to validate the chain.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing the username and password for the TPP server. The secret must contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                        url:
+                          description: 'URL is the base URL for the vedsdk endpoint of the Venafi TPP instance, for example: "https://tpp.example.com/vedsdk".'
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer. All requests made to the Venafi platform will be restricted by the named zone policy. This field is required.
+                      type: string
+            status:
+              description: Status of the Issuer. This is set and managed automatically.
+              type: object
+              properties:
+                acme:
+                  description: ACME specific status options. This field should only be set if the Issuer is configured to use an ACME server to issue certificates.
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the latest registered ACME account, in order to track changes made to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  description: List of status conditions to indicate the status of a CertificateRequest. Known condition types are `Ready`.
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details of the last transition, complementing reason.
+                        type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
+                      reason:
+                        description: Reason is a brief machine readable explanation for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, known values are (`Ready`).
+                        type: string
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+      served: true
+      storage: true
+---
+# Source: cert-manager/templates/crds.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /orders.acme.cert-manager.io
+  name: orders.acme.cert-manager.io
+  labels:
+    app: 'cert-manager'
+    app.kubernetes.io/name: 'cert-manager'
+    app.kubernetes.io/instance: 'cert-manager'
+    # Generated labels
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|orders.acme.cert-manager.io'
+spec:
+  group: acme.cert-manager.io
+  names:
+    kind: Order
+    listKind: OrderList
+    plural: orders
+    singular: order
+    categories:
+      - cert-manager
+      - cert-manager-acme
+  scope: Namespaced
+  versions:
+    - name: v1
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
+          description: Order is a type to represent an Order with an ACME server
+          type: object
+          required:
+            - metadata
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - issuerRef
+                - request
+              properties:
+                commonName:
+                  description: CommonName is the common name as specified on the DER encoded CSR. If specified, this value must also be present in `dnsNames` or `ipAddresses`. This field must match the corresponding field on the DER encoded CSR.
+                  type: string
+                dnsNames:
+                  description: DNSNames is a list of DNS names that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
+                ipAddresses:
+                  description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer which should be used to create this Order. If the Issuer does not exist, processing will be retried. If the Issuer is not an 'ACME' Issuer, an error will be returned and the Order will be marked as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      description: Group of the resource being referred to.
+                      type: string
+                    kind:
+                      description: Kind of the resource being referred to.
+                      type: string
+                    name:
+                      description: Name of the resource being referred to.
+                      type: string
+                request:
+                  description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
+                  type: string
+                  format: byte
+            status:
+              type: object
+              properties:
+                authorizations:
+                  description: Authorizations contains data returned from the ACME server on what authorizations must be completed in order to validate the DNS names specified on the Order.
+                  type: array
+                  items:
+                    description: ACMEAuthorization contains data returned from the ACME server on an authorization that must be completed in order validate a DNS name on an ACME Order resource.
+                    type: object
+                    required:
+                      - url
+                    properties:
+                      challenges:
+                        description: Challenges specifies the challenge types offered by the ACME server. One of these challenge types will be selected when validating the DNS name and an appropriate Challenge resource will be created to perform the ACME challenge process.
+                        type: array
+                        items:
+                          description: Challenge specifies a challenge offered by the ACME server for an Order. An appropriate Challenge resource can be created to perform the ACME challenge process.
+                          type: object
+                          required:
+                            - token
+                            - type
+                            - url
+                          properties:
+                            token:
+                              description: Token is the token that must be presented for this challenge. This is used to compute the 'key' that must also be presented.
+                              type: string
+                            type:
+                              description: Type is the type of challenge being offered, e.g. 'http-01', 'dns-01', 'tls-sni-01', etc. This is the raw value retrieved from the ACME server. Only 'http-01' and 'dns-01' are supported by cert-manager, other values will be ignored.
+                              type: string
+                            url:
+                              description: URL is the URL of this challenge. It can be used to retrieve additional metadata about the Challenge from the ACME server.
+                              type: string
+                      identifier:
+                        description: Identifier is the DNS name to be validated as part of this authorization
+                        type: string
+                      initialState:
+                        description: InitialState is the initial state of the ACME authorization when first fetched from the ACME server. If an Authorization is already 'valid', the Order controller will not create a Challenge resource for the authorization. This will occur when working with an ACME server that enables 'authz reuse' (such as Let's Encrypt's production endpoint). If not set and 'identifier' is set, the state is assumed to be pending and a Challenge will be created.
+                        type: string
+                        enum:
+                          - valid
+                          - ready
+                          - pending
+                          - processing
+                          - invalid
+                          - expired
+                          - errored
+                      url:
+                        description: URL is the URL of the Authorization that must be completed
+                        type: string
+                      wildcard:
+                        description: Wildcard will be true if this authorization is for a wildcard DNS name. If this is true, the identifier will be the *non-wildcard* version of the DNS name. For example, if '*.example.com' is the DNS name being validated, this field will be 'true' and the 'identifier' field will be 'example.com'.
+                        type: boolean
+                certificate:
+                  description: Certificate is a copy of the PEM encoded certificate for this Order. This field will be populated after the order has been successfully finalized with the ACME server, and the order has transitioned to the 'valid' state.
+                  type: string
+                  format: byte
+                failureTime:
+                  description: FailureTime stores the time that this order failed. This is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+                finalizeURL:
+                  description: FinalizeURL of the Order. This is used to obtain certificates for this order once it has been completed.
+                  type: string
+                reason:
+                  description: Reason optionally provides more information about a why the order is in the current state.
+                  type: string
+                state:
+                  description: State contains the current state of this Order resource. States 'success' and 'expired' are 'final'
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                url:
+                  description: URL of the Order. This will initially be empty when the resource is first created. The Order controller will populate this field when the Order is first processed. This field will be immutable after it is initially set.
+                  type: string
+      served: true
+      storage: true
+---
+# Source: cert-manager/templates/cainjector-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata: # kpt-merge: cert-manager/cert-manager-cainjector
+  name: cert-manager-cainjector
+  namespace: cert-manager
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|cert-manager|cert-manager-cainjector'
+---
+# Source: cert-manager/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata: # kpt-merge: cert-manager/cert-manager
+  name: cert-manager
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|cert-manager|cert-manager'
+---
+# Source: cert-manager/templates/webhook-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata: # kpt-merge: cert-manager/cert-manager-webhook
+  name: cert-manager-webhook
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|cert-manager|cert-manager-webhook'
+---
+# Source: cert-manager/templates/webhook-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: cert-manager/cert-manager-webhook
+  name: cert-manager-webhook
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|cert-manager|cert-manager-webhook'
+data:
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-cainjector
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-cainjector'
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "create", "update", "patch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources: ["apiservices"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "update"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Issuer controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-controller-issuers
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-controller-issuers'
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "issuers/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# ClusterIssuer controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-controller-clusterissuers
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-controller-clusterissuers'
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers", "clusterissuers/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Certificates controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-controller-certificates
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-controller-certificates'
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates/finalizers", "certificaterequests/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders"]
+    verbs: ["create", "delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Orders controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-controller-orders
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-controller-orders'
+rules:
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "orders/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "challenges"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["clusterissuers", "issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["create", "delete"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Challenges controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-controller-challenges
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-controller-challenges'
+rules:
+  # Use to update challenge resource status
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges", "challenges/status"]
+    verbs: ["update", "patch"]
+  # Used to watch challenge resources
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges"]
+    verbs: ["get", "list", "watch"]
+  # Used to watch challenges, issuer and clusterissuer resources
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  # Need to be able to retrieve ACME account private key to complete challenges
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  # Used to create events
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  # HTTP01 rules
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  # We require the ability to specify a custom hostname when we are creating
+  # new ingress resources.
+  # See: https://github.com/openshift/origin/blob/21f191775636f9acadb44fa42beeb4f75b255532/pkg/route/apiserver/admission/ingress_admission.go#L84-L148
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes/custom-host"]
+    verbs: ["create"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges/finalizers"]
+    verbs: ["update"]
+  # DNS01 rules (duplicated above)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# ingress-shim controller role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-controller-ingress-shim
+  name: cert-manager-controller-ingress-shim
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-controller-ingress-shim'
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests"]
+    verbs: ["create", "update", "delete"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch"]
+  # We require these rules to support users with the OwnerReferencesPermissionEnforcement
+  # admission controller enabled:
+  # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways", "httproutes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways/finalizers", "httproutes/finalizers"]
+    verbs: ["update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-view
+  name: cert-manager-view
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-view'
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges", "orders"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-edit
+  name: cert-manager-edit
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-edit'
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "certificaterequests", "issuers"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates/status"]
+    verbs: ["update"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["challenges", "orders"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Permission to approve CertificateRequests referencing cert-manager.io Issuers and ClusterIssuers
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-controller-approve:cert-manager-io
+  name: cert-manager-controller-approve:cert-manager-io
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cert-manager"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-controller-approve:cert-manager-io'
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["signers"]
+    verbs: ["approve"]
+    resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
+---
+# Source: cert-manager/templates/rbac.yaml
+# Permission to:
+# - Update and sign CertificatSigningeRequests referencing cert-manager.io Issuers and ClusterIssuers
+# - Perform SubjectAccessReviews to test whether users are able to reference Namespaced Issuers
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-controller-certificatesigningrequests
+  name: cert-manager-controller-certificatesigningrequests
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cert-manager"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-controller-certificatesigningrequests'
+rules:
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["certificatesigningrequests/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["certificates.k8s.io"]
+    resources: ["signers"]
+    resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
+    verbs: ["sign"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /cert-manager-webhook:subjectaccessreviews
+  name: cert-manager-webhook:subjectaccessreviews
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|cert-manager-webhook:subjectaccessreviews'
+rules:
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /cert-manager-cainjector
+  name: cert-manager-cainjector
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|cert-manager-cainjector'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-cainjector
+subjects:
+  - name: cert-manager-cainjector
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /cert-manager-controller-issuers
+  name: cert-manager-controller-issuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|cert-manager-controller-issuers'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-issuers
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /cert-manager-controller-clusterissuers
+  name: cert-manager-controller-clusterissuers
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|cert-manager-controller-clusterissuers'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-clusterissuers
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /cert-manager-controller-certificates
+  name: cert-manager-controller-certificates
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|cert-manager-controller-certificates'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-certificates
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /cert-manager-controller-orders
+  name: cert-manager-controller-orders
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|cert-manager-controller-orders'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-orders
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /cert-manager-controller-challenges
+  name: cert-manager-controller-challenges
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|cert-manager-controller-challenges'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-challenges
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /cert-manager-controller-ingress-shim
+  name: cert-manager-controller-ingress-shim
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|cert-manager-controller-ingress-shim'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-ingress-shim
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /cert-manager-controller-approve:cert-manager-io
+  name: cert-manager-controller-approve:cert-manager-io
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cert-manager"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|cert-manager-controller-approve:cert-manager-io'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-approve:cert-manager-io
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /cert-manager-controller-certificatesigningrequests
+  name: cert-manager-controller-certificatesigningrequests
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cert-manager"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|cert-manager-controller-certificatesigningrequests'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-controller-certificatesigningrequests
+subjects:
+  - name: cert-manager
+    namespace: cert-manager
+    kind: ServiceAccount
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /cert-manager-webhook:subjectaccessreviews
+  name: cert-manager-webhook:subjectaccessreviews
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|cert-manager-webhook:subjectaccessreviews'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager-webhook:subjectaccessreviews
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cert-manager-webhook
+  namespace: cert-manager
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+# leader election rules
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: # kpt-merge: kube-system/cert-manager-cainjector:leaderelection
+  name: cert-manager-cainjector:leaderelection
+  namespace: kube-system
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|kube-system|cert-manager-cainjector:leaderelection'
+rules:
+  # Used for leader election by the controller
+  # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
+  #   see cmd/cainjector/start.go#L113
+  # cert-manager-cainjector-leader-election-core is used by the SecretBased injector controller
+  #   see cmd/cainjector/start.go#L137
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: # kpt-merge: kube-system/cert-manager:leaderelection
+  name: cert-manager:leaderelection
+  namespace: kube-system
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|kube-system|cert-manager:leaderelection'
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["cert-manager-controller"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: # kpt-merge: cert-manager/cert-manager-webhook:dynamic-serving
+  name: cert-manager-webhook:dynamic-serving
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|cert-manager|cert-manager-webhook:dynamic-serving'
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames:
+  - 'cert-manager-webhook-ca'
+  verbs: ["get", "list", "watch", "update"]
+# It's not possible to grant CREATE permission on a single resourceName.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+---
+# Source: cert-manager/templates/cainjector-rbac.yaml
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: kube-system/cert-manager-cainjector:leaderelection
+  name: cert-manager-cainjector:leaderelection
+  namespace: kube-system
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|kube-system|cert-manager-cainjector:leaderelection'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-cainjector:leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager-cainjector
+    namespace: cert-manager
+---
+# Source: cert-manager/templates/rbac.yaml
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: kube-system/cert-manager:leaderelection
+  name: cert-manager:leaderelection
+  namespace: kube-system
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|kube-system|cert-manager:leaderelection'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager:leaderelection
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: cert-manager
+    namespace: cert-manager
+---
+# Source: cert-manager/templates/webhook-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: cert-manager/cert-manager-webhook:dynamic-serving
+  name: cert-manager-webhook:dynamic-serving
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|cert-manager|cert-manager-webhook:dynamic-serving'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-webhook:dynamic-serving
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cert-manager-webhook
+  namespace: cert-manager
+---
+# Source: cert-manager/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata: # kpt-merge: cert-manager/cert-manager
+  name: cert-manager
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|cert-manager|cert-manager'
+spec:
+  type: ClusterIP
+  ports:
+  - protocol: TCP
+    port: 9402
+    name: tcp-prometheus-servicemonitor
+    targetPort: 9402
+  selector:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+---
+# Source: cert-manager/templates/webhook-service.yaml
+apiVersion: v1
+kind: Service
+metadata: # kpt-merge: cert-manager/cert-manager-webhook
+  name: cert-manager-webhook
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|cert-manager|cert-manager-webhook'
+spec:
+  type: ClusterIP
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: "https"
+  selector:
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+---
+# Source: cert-manager/templates/cainjector-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: cert-manager/cert-manager-cainjector
+  name: cert-manager-cainjector
+  namespace: cert-manager
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|cert-manager|cert-manager-cainjector'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "cainjector"
+  template:
+    metadata:
+      labels:
+        app: cainjector
+        app.kubernetes.io/name: cainjector
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: "cainjector"
+        app.kubernetes.io/version: "v1.11.2"
+    spec:
+      serviceAccountName: cert-manager-cainjector
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cert-manager-cainjector
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.11.2"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=2
+            - --leader-election-namespace=kube-system
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: cert-manager/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: cert-manager/cert-manager
+  name: cert-manager
+  namespace: cert-manager
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|cert-manager|cert-manager'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "controller"
+  template:
+    metadata:
+      labels:
+        app: cert-manager
+        app.kubernetes.io/name: cert-manager
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: "controller"
+        app.kubernetes.io/version: "v1.11.2"
+      annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9402'
+    spec:
+      serviceAccountName: cert-manager
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cert-manager-controller
+          image: "quay.io/jetstack/cert-manager-controller:v1.11.2"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=2
+            - --cluster-resource-namespace=$(POD_NAMESPACE)
+            - --leader-election-namespace=kube-system
+            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.2
+            - --max-concurrent-challenges=60
+          ports:
+            - containerPort: 9402
+              name: http-metrics
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: cert-manager/templates/webhook-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: cert-manager/cert-manager-webhook
+  name: cert-manager-webhook
+  namespace: cert-manager
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|cert-manager|cert-manager-webhook'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "webhook"
+  template:
+    metadata:
+      labels:
+        app: webhook
+        app.kubernetes.io/name: webhook
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: "webhook"
+        app.kubernetes.io/version: "v1.11.2"
+    spec:
+      serviceAccountName: cert-manager-webhook
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cert-manager-webhook
+          image: "quay.io/jetstack/cert-manager-webhook:v1.11.2"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --v=2
+            - --secure-port=10250
+            - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
+            - --dynamic-serving-ca-secret-name=cert-manager-webhook-ca
+            - --dynamic-serving-dns-names=cert-manager-webhook
+            - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE)
+            - --dynamic-serving-dns-names=cert-manager-webhook.$(POD_NAMESPACE).svc
+          ports:
+            - name: https
+              protocol: TCP
+              containerPort: 10250
+            - name: healthcheck
+              protocol: TCP
+              containerPort: 6080
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 6080
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 6080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: cert-manager/templates/webhook-mutating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata: # kpt-merge: /cert-manager-webhook
+  name: cert-manager-webhook
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
+    internal.kpt.dev/upstream-identifier: 'admissionregistration.k8s.io|MutatingWebhookConfiguration|default|cert-manager-webhook'
+webhooks:
+  - name: webhook.cert-manager.io
+    rules:
+      - apiGroups:
+          - "cert-manager.io"
+          - "acme.cert-manager.io"
+        apiVersions:
+          - "v1"
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - "*/*"
+    admissionReviewVersions: ["v1"]
+    # This webhook only accepts v1 cert-manager resources.
+    # Equivalent matchPolicy ensures that non-v1 resource requests are sent to
+    # this webhook (after the resources have been converted to v1).
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    # Only include 'sideEffects' field in Kubernetes 1.12+
+    sideEffects: None
+    clientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: cert-manager
+        path: /mutate
+---
+# Source: cert-manager/templates/webhook-validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata: # kpt-merge: /cert-manager-webhook
+  name: cert-manager-webhook
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.2"
+  annotations:
+    cert-manager.io/inject-ca-from-secret: "cert-manager/cert-manager-webhook-ca"
+    internal.kpt.dev/upstream-identifier: 'admissionregistration.k8s.io|ValidatingWebhookConfiguration|default|cert-manager-webhook'
+webhooks:
+  - name: webhook.cert-manager.io
+    namespaceSelector:
+      matchExpressions:
+        - key: "cert-manager.io/disable-validation"
+          operator: "NotIn"
+          values:
+            - "true"
+        - key: "name"
+          operator: "NotIn"
+          values:
+            - cert-manager
+    rules:
+      - apiGroups:
+          - "cert-manager.io"
+          - "acme.cert-manager.io"
+        apiVersions:
+          - "v1"
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - "*/*"
+    admissionReviewVersions: ["v1"]
+    # This webhook only accepts v1 cert-manager resources.
+    # Equivalent matchPolicy ensures that non-v1 resource requests are sent to
+    # this webhook (after the resources have been converted to v1).
+    matchPolicy: Equivalent
+    timeoutSeconds: 10
+    failurePolicy: Fail
+    sideEffects: None
+    clientConfig:
+      service:
+        name: cert-manager-webhook
+        namespace: cert-manager
+        path: /validate

--- a/nephio-r1-sandbox/cert-manager/package-context.yaml
+++ b/nephio-r1-sandbox/cert-manager/package-context.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: /kptfile.kpt.dev
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|kptfile.kpt.dev'
+data:
+  name: example

--- a/nephio-r1-sandbox/cluster-capi-infrastructure-docker/Kptfile
+++ b/nephio-r1-sandbox/cluster-capi-infrastructure-docker/Kptfile
@@ -1,0 +1,22 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: cluster-capi-infrastructure-docker
+  annotations:
+    config.kubernetes.io/local-config: "true"
+upstream:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /cluster-capi-infrastructure-docker
+    ref: cluster-capi-infrastructure-docker/v1
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /cluster-capi-infrastructure-docker
+    ref: cluster-capi-infrastructure-docker/v1
+    commit: 3c2fc2a655f0362fa26ed1fa179f01d6bb1dd84d
+info:
+  description: cluster-api docker provider package

--- a/nephio-r1-sandbox/cluster-capi-infrastructure-docker/README.md
+++ b/nephio-r1-sandbox/cluster-capi-infrastructure-docker/README.md
@@ -1,0 +1,11 @@
+# cluster-capi-infrastructure-docker
+
+## Description
+
+cluster-api docker provider package
+
+## build
+
+```
+clusterctl generate provider --infrastructure docker > cluster-api-infrastructure-docker.yaml
+```

--- a/nephio-r1-sandbox/cluster-capi-infrastructure-docker/cluster-api-infrastructure-docker.yaml
+++ b/nephio-r1-sandbox/cluster-capi-infrastructure-docker/cluster-api-infrastructure-docker.yaml
@@ -1,0 +1,2194 @@
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /capd-system
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: capd-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|capd-system'
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /dockerclusters.infrastructure.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.11.4
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|dockerclusters.infrastructure.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+    clusterctl.cluster.x-k8s.io: ""
+  name: dockerclusters.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerCluster
+    listKind: DockerClusterList
+    plural: dockerclusters
+    singular: dockercluster
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: "DockerCluster is the Schema for the dockerclusters API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerClusterSpec defines the desired state of DockerCluster.
+            properties:
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                properties:
+                  host:
+                    description: Host is the hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: Port is the port on which the API server is serving.
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains are not usulaly defined on the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.
+                type: object
+            type: object
+          status:
+            description: DockerClusterStatus defines the observed state of DockerCluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the DockerCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains don't mean much in CAPD since it's all local, but we can see how the rest of cluster API will use this if we populate it.
+                type: object
+              ready:
+                description: Ready denotes that the docker cluster (infrastructure) is ready.
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "DockerCluster is the Schema for the dockerclusters API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerClusterSpec defines the desired state of DockerCluster.
+            properties:
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                properties:
+                  host:
+                    description: Host is the hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: Port is the port on which the API server is serving.
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains are not usulaly defined on the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.
+                type: object
+              loadBalancer:
+                description: LoadBalancer allows defining configurations for the cluster load balancer.
+                properties:
+                  imageRepository:
+                    description: ImageRepository sets the container registry to pull the haproxy image from. if not set, "kindest" will be used instead.
+                    type: string
+                  imageTag:
+                    description: ImageTag allows to specify a tag for the haproxy image. if not set, "v20210715-a6da3463" will be used instead.
+                    type: string
+                type: object
+            type: object
+          status:
+            description: DockerClusterStatus defines the observed state of DockerCluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the DockerCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains don't mean much in CAPD since it's all local, but we can see how the rest of cluster API will use this if we populate it.
+                type: object
+              ready:
+                description: Ready denotes that the docker cluster (infrastructure) is ready.
+                type: boolean
+            required:
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Time duration since creation of DockerCluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerCluster is the Schema for the dockerclusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerClusterSpec defines the desired state of DockerCluster.
+            properties:
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                properties:
+                  host:
+                    description: Host is the hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: Port is the port on which the API server is serving. Defaults to 6443 if not set.
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains are usually not defined in the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.
+                type: object
+              loadBalancer:
+                description: LoadBalancer allows defining configurations for the cluster load balancer.
+                properties:
+                  imageRepository:
+                    description: ImageRepository sets the container registry to pull the haproxy image from. if not set, "kindest" will be used instead.
+                    type: string
+                  imageTag:
+                    description: ImageTag allows to specify a tag for the haproxy image. if not set, "v20210715-a6da3463" will be used instead.
+                    type: string
+                type: object
+            type: object
+          status:
+            description: DockerClusterStatus defines the observed state of DockerCluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the DockerCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains don't mean much in CAPD since it's all local, but we can see how the rest of cluster API will use this if we populate it.
+                type: object
+              ready:
+                description: Ready denotes that the docker cluster (infrastructure) is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /dockerclustertemplates.infrastructure.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.11.4
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|dockerclustertemplates.infrastructure.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+    clusterctl.cluster.x-k8s.io: ""
+  name: dockerclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerClusterTemplate
+    listKind: DockerClusterTemplateList
+    plural: dockerclustertemplates
+    singular: dockerclustertemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerClusterTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "DockerClusterTemplate is the Schema for the dockerclustertemplates API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerClusterTemplateSpec defines the desired state of DockerClusterTemplate.
+            properties:
+              template:
+                description: DockerClusterTemplateResource describes the data needed to create a DockerCluster from a template.
+                properties:
+                  spec:
+                    description: DockerClusterSpec defines the desired state of DockerCluster.
+                    properties:
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                        properties:
+                          host:
+                            description: Host is the hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: Port is the port on which the API server is serving.
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      failureDomains:
+                        additionalProperties:
+                          description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                              type: object
+                            controlPlane:
+                              description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                              type: boolean
+                          type: object
+                        description: FailureDomains are not usulaly defined on the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.
+                        type: object
+                      loadBalancer:
+                        description: LoadBalancer allows defining configurations for the cluster load balancer.
+                        properties:
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull the haproxy image from. if not set, "kindest" will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the haproxy image. if not set, "v20210715-a6da3463" will be used instead.
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerClusterTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerClusterTemplate is the Schema for the dockerclustertemplates API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerClusterTemplateSpec defines the desired state of DockerClusterTemplate.
+            properties:
+              template:
+                description: DockerClusterTemplateResource describes the data needed to create a DockerCluster from a template.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: DockerClusterSpec defines the desired state of DockerCluster.
+                    properties:
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                        properties:
+                          host:
+                            description: Host is the hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: Port is the port on which the API server is serving. Defaults to 6443 if not set.
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      failureDomains:
+                        additionalProperties:
+                          description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                              type: object
+                            controlPlane:
+                              description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                              type: boolean
+                          type: object
+                        description: FailureDomains are usually not defined in the spec. The docker provider is special since failure domains don't mean anything in a local docker environment. Instead, the docker cluster controller will simply copy these into the Status and allow the Cluster API controllers to do what they will with the defined failure domains.
+                        type: object
+                      loadBalancer:
+                        description: LoadBalancer allows defining configurations for the cluster load balancer.
+                        properties:
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull the haproxy image from. if not set, "kindest" will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the haproxy image. if not set, "v20210715-a6da3463" will be used instead.
+                            type: string
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /dockermachinepools.infrastructure.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.11.4
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|dockermachinepools.infrastructure.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+    clusterctl.cluster.x-k8s.io: ""
+  name: dockermachinepools.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerMachinePool
+    listKind: DockerMachinePoolList
+    plural: dockermachinepools
+    singular: dockermachinepool
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: "DockerMachinePool is the Schema for the dockermachinepools API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachinePoolSpec defines the desired state of DockerMachinePool.
+            properties:
+              providerID:
+                description: ProviderID is the identification ID of the Machine Pool
+                type: string
+              providerIDList:
+                description: ProviderIDList is the list of identification IDs of machine instances managed by this Machine Pool
+                items:
+                  type: string
+                type: array
+              template:
+                description: Template contains the details used to build a replica machine within the Machine Pool
+                properties:
+                  customImage:
+                    description: CustomImage allows customizing the container image that is used for running the machine
+                    type: string
+                  extraMounts:
+                    description: ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath
+                    items:
+                      description: Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.
+                      properties:
+                        containerPath:
+                          description: Path of the mount within the container.
+                          type: string
+                        hostPath:
+                          description: Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.
+                          type: string
+                        readOnly:
+                          description: If set, the mount is read-only.
+                          type: boolean
+                      type: object
+                    type: array
+                  preLoadImages:
+                    description: PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+          status:
+            description: DockerMachinePoolStatus defines the observed state of DockerMachinePool.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the DockerMachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              instances:
+                description: Instances contains the status for each instance in the pool
+                items:
+                  description: DockerMachinePoolInstanceStatus contains status information about a DockerMachinePool.
+                  properties:
+                    addresses:
+                      description: Addresses contains the associated addresses for the docker machine.
+                      items:
+                        description: MachineAddress contains information for the node's address.
+                        properties:
+                          address:
+                            description: The machine address.
+                            type: string
+                          type:
+                            description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                            type: string
+                        required:
+                        - address
+                        - type
+                        type: object
+                      type: array
+                    bootstrapped:
+                      description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                      type: boolean
+                    instanceName:
+                      description: InstanceName is the identification of the Machine Instance within the Machine Pool
+                      type: string
+                    providerID:
+                      description: ProviderID is the provider identification of the Machine Pool Instance
+                      type: string
+                    ready:
+                      description: Ready denotes that the machine (docker container) is ready
+                      type: boolean
+                    version:
+                      description: Version defines the Kubernetes version for the Machine Instance
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the machine pool is ready
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "DockerMachinePool is the Schema for the dockermachinepools API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachinePoolSpec defines the desired state of DockerMachinePool.
+            properties:
+              providerID:
+                description: ProviderID is the identification ID of the Machine Pool
+                type: string
+              providerIDList:
+                description: ProviderIDList is the list of identification IDs of machine instances managed by this Machine Pool
+                items:
+                  type: string
+                type: array
+              template:
+                description: Template contains the details used to build a replica machine within the Machine Pool
+                properties:
+                  customImage:
+                    description: CustomImage allows customizing the container image that is used for running the machine
+                    type: string
+                  extraMounts:
+                    description: ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath
+                    items:
+                      description: Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.
+                      properties:
+                        containerPath:
+                          description: Path of the mount within the container.
+                          type: string
+                        hostPath:
+                          description: Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.
+                          type: string
+                        readOnly:
+                          description: If set, the mount is read-only.
+                          type: boolean
+                      type: object
+                    type: array
+                  preLoadImages:
+                    description: PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+          status:
+            description: DockerMachinePoolStatus defines the observed state of DockerMachinePool.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the DockerMachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              instances:
+                description: Instances contains the status for each instance in the pool
+                items:
+                  description: DockerMachinePoolInstanceStatus contains status information about a DockerMachinePool.
+                  properties:
+                    addresses:
+                      description: Addresses contains the associated addresses for the docker machine.
+                      items:
+                        description: MachineAddress contains information for the node's address.
+                        properties:
+                          address:
+                            description: The machine address.
+                            type: string
+                          type:
+                            description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                            type: string
+                        required:
+                        - address
+                        - type
+                        type: object
+                      type: array
+                    bootstrapped:
+                      description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                      type: boolean
+                    instanceName:
+                      description: InstanceName is the identification of the Machine Instance within the Machine Pool
+                      type: string
+                    providerID:
+                      description: ProviderID is the provider identification of the Machine Pool Instance
+                      type: string
+                    ready:
+                      description: Ready denotes that the machine (docker container) is ready
+                      type: boolean
+                    version:
+                      description: Version defines the Kubernetes version for the Machine Instance
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the machine pool is ready
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerMachinePool is the Schema for the dockermachinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachinePoolSpec defines the desired state of DockerMachinePool.
+            properties:
+              providerID:
+                description: ProviderID is the identification ID of the Machine Pool
+                type: string
+              providerIDList:
+                description: ProviderIDList is the list of identification IDs of machine instances managed by this Machine Pool
+                items:
+                  type: string
+                type: array
+              template:
+                description: Template contains the details used to build a replica machine within the Machine Pool
+                properties:
+                  customImage:
+                    description: CustomImage allows customizing the container image that is used for running the machine
+                    type: string
+                  extraMounts:
+                    description: ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath
+                    items:
+                      description: Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.
+                      properties:
+                        containerPath:
+                          description: Path of the mount within the container.
+                          type: string
+                        hostPath:
+                          description: Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.
+                          type: string
+                        readOnly:
+                          description: If set, the mount is read-only.
+                          type: boolean
+                      type: object
+                    type: array
+                  preLoadImages:
+                    description: PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+          status:
+            description: DockerMachinePoolStatus defines the observed state of DockerMachinePool.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the DockerMachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              instances:
+                description: Instances contains the status for each instance in the pool
+                items:
+                  description: DockerMachinePoolInstanceStatus contains status information about a DockerMachinePool.
+                  properties:
+                    addresses:
+                      description: Addresses contains the associated addresses for the docker machine.
+                      items:
+                        description: MachineAddress contains information for the node's address.
+                        properties:
+                          address:
+                            description: The machine address.
+                            type: string
+                          type:
+                            description: Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                            type: string
+                        required:
+                        - address
+                        - type
+                        type: object
+                      type: array
+                    bootstrapped:
+                      description: "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine \n Deprecated: This field will be removed in the next apiVersion. When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml"
+                      type: boolean
+                    instanceName:
+                      description: InstanceName is the identification of the Machine Instance within the Machine Pool
+                      type: string
+                    providerID:
+                      description: ProviderID is the provider identification of the Machine Pool Instance
+                      type: string
+                    ready:
+                      description: Ready denotes that the machine (docker container) is ready
+                      type: boolean
+                    version:
+                      description: Version defines the Kubernetes version for the Machine Instance
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the machine pool is ready
+                type: boolean
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /dockermachines.infrastructure.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.11.4
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|dockermachines.infrastructure.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+    clusterctl.cluster.x-k8s.io: ""
+  name: dockermachines.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerMachine
+    listKind: DockerMachineList
+    plural: dockermachines
+    singular: dockermachine
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: "DockerMachine is the Schema for the dockermachines API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachineSpec defines the desired state of DockerMachine.
+            properties:
+              bootstrapped:
+                description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                type: boolean
+              customImage:
+                description: CustomImage allows customizing the container image that is used for running the machine
+                type: string
+              extraMounts:
+                description: ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath
+                items:
+                  description: Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.
+                  properties:
+                    containerPath:
+                      description: Path of the mount within the container.
+                      type: string
+                    hostPath:
+                      description: Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.
+                      type: string
+                    readOnly:
+                      description: If set, the mount is read-only.
+                      type: boolean
+                  type: object
+                type: array
+              preLoadImages:
+                description: PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.
+                items:
+                  type: string
+                type: array
+              providerID:
+                description: ProviderID will be the container name in ProviderID format (docker:////<containername>)
+                type: string
+            type: object
+          status:
+            description: DockerMachineStatus defines the observed state of DockerMachine.
+            properties:
+              addresses:
+                description: Addresses contains the associated addresses for the docker machine.
+                items:
+                  description: MachineAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the DockerMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              loadBalancerConfigured:
+                description: LoadBalancerConfigured denotes that the machine has been added to the load balancer
+                type: boolean
+              ready:
+                description: Ready denotes that the machine (docker container) is ready
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "DockerMachine is the Schema for the dockermachines API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachineSpec defines the desired state of DockerMachine.
+            properties:
+              bootstrapped:
+                description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                type: boolean
+              customImage:
+                description: CustomImage allows customizing the container image that is used for running the machine
+                type: string
+              extraMounts:
+                description: ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath
+                items:
+                  description: Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.
+                  properties:
+                    containerPath:
+                      description: Path of the mount within the container.
+                      type: string
+                    hostPath:
+                      description: Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.
+                      type: string
+                    readOnly:
+                      description: If set, the mount is read-only.
+                      type: boolean
+                  type: object
+                type: array
+              preLoadImages:
+                description: PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.
+                items:
+                  type: string
+                type: array
+              providerID:
+                description: ProviderID will be the container name in ProviderID format (docker:////<containername>)
+                type: string
+            type: object
+          status:
+            description: DockerMachineStatus defines the observed state of DockerMachine.
+            properties:
+              addresses:
+                description: Addresses contains the associated addresses for the docker machine.
+                items:
+                  description: MachineAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the DockerMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              loadBalancerConfigured:
+                description: LoadBalancerConfigured denotes that the machine has been added to the load balancer
+                type: boolean
+              ready:
+                description: Ready denotes that the machine (docker container) is ready
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Machine object which owns with this DockerMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Time duration since creation of DockerMachine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerMachine is the Schema for the dockermachines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachineSpec defines the desired state of DockerMachine.
+            properties:
+              bootstrapped:
+                description: "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine \n Deprecated: This field will be removed in the next apiVersion. When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml."
+                type: boolean
+              customImage:
+                description: CustomImage allows customizing the container image that is used for running the machine
+                type: string
+              extraMounts:
+                description: ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath
+                items:
+                  description: Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.
+                  properties:
+                    containerPath:
+                      description: Path of the mount within the container.
+                      type: string
+                    hostPath:
+                      description: Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.
+                      type: string
+                    readOnly:
+                      description: If set, the mount is read-only.
+                      type: boolean
+                  type: object
+                type: array
+              preLoadImages:
+                description: PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.
+                items:
+                  type: string
+                type: array
+              providerID:
+                description: ProviderID will be the container name in ProviderID format (docker:////<containername>)
+                type: string
+            type: object
+          status:
+            description: DockerMachineStatus defines the observed state of DockerMachine.
+            properties:
+              addresses:
+                description: Addresses contains the associated addresses for the docker machine.
+                items:
+                  description: MachineAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the DockerMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              loadBalancerConfigured:
+                description: LoadBalancerConfigured denotes that the machine has been added to the load balancer
+                type: boolean
+              ready:
+                description: Ready denotes that the machine (docker container) is ready
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /dockermachinetemplates.infrastructure.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    controller-gen.kubebuilder.io/version: v0.11.4
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|dockermachinetemplates.infrastructure.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+    clusterctl.cluster.x-k8s.io: ""
+  name: dockermachinetemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capd-webhook-service
+          namespace: capd-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: DockerMachineTemplate
+    listKind: DockerMachineTemplateList
+    plural: dockermachinetemplates
+    singular: dockermachinetemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: "DockerMachineTemplate is the Schema for the dockermachinetemplates API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.
+            properties:
+              template:
+                description: DockerMachineTemplateResource describes the data needed to create a DockerMachine from a template.
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior of the machine.
+                    properties:
+                      bootstrapped:
+                        description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                        type: boolean
+                      customImage:
+                        description: CustomImage allows customizing the container image that is used for running the machine
+                        type: string
+                      extraMounts:
+                        description: ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath
+                        items:
+                          description: Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.
+                          properties:
+                            containerPath:
+                              description: Path of the mount within the container.
+                              type: string
+                            hostPath:
+                              description: Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.
+                              type: string
+                            readOnly:
+                              description: If set, the mount is read-only.
+                              type: boolean
+                          type: object
+                        type: array
+                      preLoadImages:
+                        description: PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.
+                        items:
+                          type: string
+                        type: array
+                      providerID:
+                        description: ProviderID will be the container name in ProviderID format (docker:////<containername>)
+                        type: string
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachineTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: "DockerMachineTemplate is the Schema for the dockermachinetemplates API. \n Deprecated: This type will be removed in one of the next releases."
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.
+            properties:
+              template:
+                description: DockerMachineTemplateResource describes the data needed to create a DockerMachine from a template.
+                properties:
+                  spec:
+                    description: Spec is the specification of the desired behavior of the machine.
+                    properties:
+                      bootstrapped:
+                        description: Bootstrapped is true when the kubeadm bootstrapping has been run against this machine
+                        type: boolean
+                      customImage:
+                        description: CustomImage allows customizing the container image that is used for running the machine
+                        type: string
+                      extraMounts:
+                        description: ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath
+                        items:
+                          description: Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.
+                          properties:
+                            containerPath:
+                              description: Path of the mount within the container.
+                              type: string
+                            hostPath:
+                              description: Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.
+                              type: string
+                            readOnly:
+                              description: If set, the mount is read-only.
+                              type: boolean
+                          type: object
+                        type: array
+                      preLoadImages:
+                        description: PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.
+                        items:
+                          type: string
+                        type: array
+                      providerID:
+                        description: ProviderID will be the container name in ProviderID format (docker:////<containername>)
+                        type: string
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of DockerMachineTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: DockerMachineTemplate is the Schema for the dockermachinetemplates API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DockerMachineTemplateSpec defines the desired state of DockerMachineTemplate.
+            properties:
+              template:
+                description: DockerMachineTemplateResource describes the data needed to create a DockerMachine from a template.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the desired behavior of the machine.
+                    properties:
+                      bootstrapped:
+                        description: "Bootstrapped is true when the kubeadm bootstrapping has been run against this machine \n Deprecated: This field will be removed in the next apiVersion. When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml."
+                        type: boolean
+                      customImage:
+                        description: CustomImage allows customizing the container image that is used for running the machine
+                        type: string
+                      extraMounts:
+                        description: ExtraMounts describes additional mount points for the node container These may be used to bind a hostPath
+                        items:
+                          description: Mount specifies a host volume to mount into a container. This is a simplified version of kind v1alpha4.Mount types.
+                          properties:
+                            containerPath:
+                              description: Path of the mount within the container.
+                              type: string
+                            hostPath:
+                              description: Path of the mount on the host. If the hostPath doesn't exist, then runtimes should report error. If the hostpath is a symbolic link, runtimes should follow the symlink and mount the real destination to container.
+                              type: string
+                            readOnly:
+                              description: If set, the mount is read-only.
+                              type: boolean
+                          type: object
+                        type: array
+                      preLoadImages:
+                        description: PreLoadImages allows to pre-load images in a newly created machine. This can be used to speed up tests by avoiding e.g. to download CNI images on all the containers.
+                        items:
+                          type: string
+                        type: array
+                      providerID:
+                        description: ProviderID will be the container name in ProviderID format (docker:////<containername>)
+                        type: string
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: # kpt-merge: capd-system/capd-manager
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+  name: capd-manager
+  namespace: capd-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|capd-system|capd-manager'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: # kpt-merge: capd-system/capd-leader-election-role
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+  name: capd-leader-election-role
+  namespace: capd-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|capd-system|capd-leader-election-role'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /capd-manager-role
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+  name: capd-manager-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|capd-manager-role'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - machines
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockerclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockerclusters/finalizers
+  - dockerclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockermachinepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockermachinepools/finalizers
+  - dockermachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockermachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dockermachines/finalizers
+  - dockermachines/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: capd-system/capd-leader-election-rolebinding
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+  name: capd-leader-election-rolebinding
+  namespace: capd-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|capd-system|capd-leader-election-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capd-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capd-manager
+  namespace: capd-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /capd-manager-rolebinding
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+  name: capd-manager-rolebinding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|capd-manager-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capd-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capd-manager
+  namespace: capd-system
+---
+apiVersion: v1
+kind: Service
+metadata: # kpt-merge: capd-system/capd-webhook-service
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+  name: capd-webhook-service
+  namespace: capd-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|capd-system|capd-webhook-service'
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: infrastructure-docker
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: capd-system/capd-controller-manager
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  name: capd-controller-manager
+  namespace: capd-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|capd-system|capd-controller-manager'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: infrastructure-docker
+      control-plane: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        cluster.x-k8s.io/provider: infrastructure-docker
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --metrics-bind-addr=localhost:8080
+        - --feature-gates=MachinePool=false,ClusterTopology=true
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
+        - name: DOCKER_HOST
+        image: gcr.io/k8s-staging-cluster-api/capd-manager:v1.4.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /var/run/docker.sock
+          name: dockersock
+      serviceAccountName: capd-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capd-webhook-service-cert
+      - hostPath:
+          path: /var/run/docker.sock
+        name: dockersock
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata: # kpt-merge: capd-system/capd-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+  name: capd-serving-cert
+  namespace: capd-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'cert-manager.io|Certificate|capd-system|capd-serving-cert'
+spec:
+  dnsNames:
+  - capd-webhook-service.capd-system.svc
+  - capd-webhook-service.capd-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capd-selfsigned-issuer
+  secretName: capd-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata: # kpt-merge: capd-system/capd-selfsigned-issuer
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+  name: capd-selfsigned-issuer
+  namespace: capd-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'cert-manager.io|Issuer|capd-system|capd-selfsigned-issuer'
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata: # kpt-merge: /capd-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    internal.kpt.dev/upstream-identifier: 'admissionregistration.k8s.io|MutatingWebhookConfiguration|default|capd-mutating-webhook-configuration'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+  name: capd-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capd-webhook-service
+      namespace: capd-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-dockercluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.dockercluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockerclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capd-webhook-service
+      namespace: capd-system
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-dockerclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.dockerclustertemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockerclustertemplates
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata: # kpt-merge: /capd-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: capd-system/capd-serving-cert
+    internal.kpt.dev/upstream-identifier: 'admissionregistration.k8s.io|ValidatingWebhookConfiguration|default|capd-validating-webhook-configuration'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-docker
+    clusterctl.cluster.x-k8s.io: ""
+  name: capd-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capd-webhook-service
+      namespace: capd-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-dockercluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.dockercluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockerclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capd-webhook-service
+      namespace: capd-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-dockerclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.dockerclustertemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockerclustertemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capd-webhook-service
+      namespace: capd-system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-dockermachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.dockermachinetemplate.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - dockermachinetemplates
+  sideEffects: None

--- a/nephio-r1-sandbox/cluster-capi-infrastructure-docker/package-context.yaml
+++ b/nephio-r1-sandbox/cluster-capi-infrastructure-docker/package-context.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: /kptfile.kpt.dev
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|kptfile.kpt.dev'
+data:
+  name: example

--- a/nephio-r1-sandbox/cluster-capi-kind-docker-templates/Kptfile
+++ b/nephio-r1-sandbox/cluster-capi-kind-docker-templates/Kptfile
@@ -1,0 +1,22 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: cluster-capi-kind-docker-templates
+  annotations:
+    config.kubernetes.io/local-config: "true"
+upstream:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /cluster-capi-kind-docker-templates
+    ref: cluster-capi-kind-docker-templates/v1
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /cluster-capi-kind-docker-templates
+    ref: cluster-capi-kind-docker-templates/v1
+    commit: 4edc7acc8a3aa3339c5e62206a5a7845de37414d
+info:
+  description: This package provides the templates and classes for docker kind capi clusters

--- a/nephio-r1-sandbox/cluster-capi-kind-docker-templates/README.md
+++ b/nephio-r1-sandbox/cluster-capi-kind-docker-templates/README.md
@@ -1,0 +1,9 @@
+# cluster
+
+## Description
+
+This package provides the templates and classes for docker kind capi clusters
+
+The package has some host dependencies:
+- /opt/cni/bin for accessing the cni(s)
+- /var/run/docker.sock for the docker socket

--- a/nephio-r1-sandbox/cluster-capi-kind-docker-templates/cluster_class.yaml
+++ b/nephio-r1-sandbox/cluster-capi-kind-docker-templates/cluster_class.yaml
@@ -1,0 +1,238 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: ClusterClass
+metadata: # kpt-merge: default/docker
+  name: docker
+  namespace: default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'cluster.x-k8s.io|ClusterClass|default|docker'
+spec:
+  controlPlane:
+    machineInfrastructure:
+      ref:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        name: docker-control-plane
+    ref:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+      kind: KubeadmControlPlaneTemplate
+      name: docker-control-plane
+  infrastructure:
+    ref:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerClusterTemplate
+      name: docker-cluster
+  patches:
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/imageRepository
+        valueFrom:
+          variable: imageRepository
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    description: Sets the imageRepository used for the KubeadmControlPlane.
+    enabledIf: '{{ ne .imageRepository "" }}'
+    name: imageRepository
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs/cgroup-driver
+        value: cgroupfs
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs/cgroup-driver
+        value: cgroupfs
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    description: |
+      Sets the cgroupDriver to cgroupfs if a Kubernetes version < v1.24 is referenced.
+      This is required because kind and the node images do not support the default
+      systemd cgroupDriver for kubernetes < v1.24.
+    enabledIf: '{{ semverCompare "<= v1.23" .builtin.controlPlane.version }}'
+    name: cgroupDriver-controlPlane
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/cgroup-driver
+        value: cgroupfs
+      selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - docker-default-worker
+    description: |
+      Sets the cgroupDriver to cgroupfs if a Kubernetes version < v1.24 is referenced.
+      This is required because kind and the node images do not support the default
+      systemd cgroupDriver for kubernetes < v1.24.
+    enabledIf: '{{ semverCompare "<= v1.23" .builtin.machineDeployment.version }}'
+    name: cgroupDriver-machineDeployment
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd
+        valueFrom:
+          template: |
+            local:
+              imageTag: {{ .etcdImageTag }}
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    description: Sets tag to use for the etcd image in the KubeadmControlPlane.
+    name: etcdImageTag
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/dns
+        valueFrom:
+          template: |
+            imageTag: {{ .coreDNSImageTag }}
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    description: Sets tag to use for the etcd image in the KubeadmControlPlane.
+    name: coreDNSImageTag
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/customImage
+        valueFrom:
+          template: |
+            kindest/node:{{ .builtin.machineDeployment.version | replace "+" "_" }}
+      selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - docker-default-worker
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/customImage
+        valueFrom:
+          template: |
+            kindest/node:{{ .builtin.controlPlane.version | replace "+" "_" }}
+      selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: DockerMachineTemplate
+        matchResources:
+          controlPlane: true
+    description: Sets the container image that is used for running dockerMachines for the controlPlane and docker-default-worker machineDeployments.
+    name: customImage
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs
+        value:
+          admission-control-config-file: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+        value:
+        - hostPath: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+          mountPath: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+          name: admission-pss
+          pathType: File
+          readOnly: true
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files
+        valueFrom:
+          template: |
+            - content: |
+                apiVersion: apiserver.config.k8s.io/v1
+                kind: AdmissionConfiguration
+                plugins:
+                - name: PodSecurity
+                  configuration:
+                    apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25" .builtin.controlPlane.version }}beta1{{ end }}
+                    kind: PodSecurityConfiguration
+                    defaults:
+                      enforce: "{{ .podSecurityStandard.enforce }}"
+                      enforce-version: "latest"
+                      audit: "{{ .podSecurityStandard.audit }}"
+                      audit-version: "latest"
+                      warn: "{{ .podSecurityStandard.warn }}"
+                      warn-version: "latest"
+                    exemptions:
+                      usernames: []
+                      runtimeClasses: []
+                      namespaces: [kube-system]
+              path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    description: Adds an admission configuration for PodSecurity to the kube-apiserver.
+    enabledIf: '{{ .podSecurityStandard.enabled }}'
+    name: podSecurityStandard
+  variables:
+  - name: imageRepository
+    required: true
+    schema:
+      openAPIV3Schema:
+        default: ""
+        description: imageRepository sets the container registry to pull images from. If empty, nothing will be set and the from of kubeadm will be used.
+        example: registry.k8s.io
+        type: string
+  - name: etcdImageTag
+    required: true
+    schema:
+      openAPIV3Schema:
+        default: ""
+        description: etcdImageTag sets the tag for the etcd image.
+        example: 3.5.3-0
+        type: string
+  - name: coreDNSImageTag
+    required: true
+    schema:
+      openAPIV3Schema:
+        default: ""
+        description: coreDNSImageTag sets the tag for the coreDNS image.
+        example: v1.8.5
+        type: string
+  - name: podSecurityStandard
+    required: false
+    schema:
+      openAPIV3Schema:
+        properties:
+          audit:
+            default: restricted
+            description: audit sets the level for the audit PodSecurityConfiguration mode. One of privileged, baseline, restricted.
+            type: string
+          enabled:
+            default: true
+            description: enabled enables the patches to enable Pod Security Standard via AdmissionConfiguration.
+            type: boolean
+          enforce:
+            default: baseline
+            description: enforce sets the level for the enforce PodSecurityConfiguration mode. One of privileged, baseline, restricted.
+            type: string
+          warn:
+            default: restricted
+            description: warn sets the level for the warn PodSecurityConfiguration mode. One of privileged, baseline, restricted.
+            type: string
+        type: object
+  workers:
+    machineDeployments:
+    - class: docker-default-worker
+      template:
+        bootstrap:
+          ref:
+            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+            kind: KubeadmConfigTemplate
+            name: docker-default-worker-bootstraptemplate
+        infrastructure:
+          ref:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: DockerMachineTemplate
+            name: docker-default-worker-machinetemplate

--- a/nephio-r1-sandbox/cluster-capi-kind-docker-templates/docker_cluster_template.yaml
+++ b/nephio-r1-sandbox/cluster-capi-kind-docker-templates/docker_cluster_template.yaml
@@ -1,0 +1,10 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerClusterTemplate
+metadata: # kpt-merge: default/docker-cluster
+  name: docker-cluster
+  namespace: default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'infrastructure.cluster.x-k8s.io|DockerClusterTemplate|default|docker-cluster'
+spec:
+  template:
+    spec: {}

--- a/nephio-r1-sandbox/cluster-capi-kind-docker-templates/docker_machine_template_control_plane.yaml
+++ b/nephio-r1-sandbox/cluster-capi-kind-docker-templates/docker_machine_template_control_plane.yaml
@@ -1,0 +1,15 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata: # kpt-merge: default/docker-control-plane
+  name: docker-control-plane
+  namespace: default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'infrastructure.cluster.x-k8s.io|DockerMachineTemplate|default|docker-control-plane'
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: /var/run/docker.sock
+        hostPath: /var/run/docker.sock
+      - containerPath: /opt/cni/bin
+        hostPath: /opt/cni/bin

--- a/nephio-r1-sandbox/cluster-capi-kind-docker-templates/docker_machine_template_worker.yaml
+++ b/nephio-r1-sandbox/cluster-capi-kind-docker-templates/docker_machine_template_worker.yaml
@@ -1,0 +1,15 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerMachineTemplate
+metadata: # kpt-merge: default/docker-default-worker-machinetemplate
+  name: docker-default-worker-machinetemplate
+  namespace: default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'infrastructure.cluster.x-k8s.io|DockerMachineTemplate|default|docker-default-worker-machinetemplate'
+spec:
+  template:
+    spec:
+      extraMounts:
+      - containerPath: /var/run/docker.sock
+        hostPath: /var/run/docker.sock
+      - containerPath: /opt/cni/bin
+        hostPath: /opt/cni/bin

--- a/nephio-r1-sandbox/cluster-capi-kind-docker-templates/kubeadm_config_template.yaml
+++ b/nephio-r1-sandbox/cluster-capi-kind-docker-templates/kubeadm_config_template.yaml
@@ -1,0 +1,15 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata: # kpt-merge: default/docker-default-worker-bootstraptemplate
+  name: docker-default-worker-bootstraptemplate
+  namespace: default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'bootstrap.cluster.x-k8s.io|KubeadmConfigTemplate|default|docker-default-worker-bootstraptemplate'
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: unix:///var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%

--- a/nephio-r1-sandbox/cluster-capi-kind-docker-templates/kubeadm_controlplane_template.yaml
+++ b/nephio-r1-sandbox/cluster-capi-kind-docker-templates/kubeadm_controlplane_template.yaml
@@ -1,0 +1,31 @@
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlaneTemplate
+metadata: # kpt-merge: default/docker-control-plane
+  name: docker-control-plane
+  namespace: default
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'controlplane.cluster.x-k8s.io|KubeadmControlPlaneTemplate|default|docker-control-plane'
+spec:
+  template:
+    spec:
+      kubeadmConfigSpec:
+        clusterConfiguration:
+          apiServer:
+            certSANs:
+            - localhost
+            - 127.0.0.1
+            - 0.0.0.0
+            - host.docker.internal
+          controllerManager:
+            extraArgs:
+              enable-hostpath-provisioner: "true"
+        initConfiguration:
+          nodeRegistration:
+            criSocket: unix:///var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+        joinConfiguration:
+          nodeRegistration:
+            criSocket: unix:///var/run/containerd/containerd.sock
+            kubeletExtraArgs:
+              eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%

--- a/nephio-r1-sandbox/cluster-capi-kind-docker-templates/package-context.yaml
+++ b/nephio-r1-sandbox/cluster-capi-kind-docker-templates/package-context.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: /kptfile.kpt.dev
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|kptfile.kpt.dev'
+data:
+  name: example

--- a/nephio-r1-sandbox/cluster-capi/Kptfile
+++ b/nephio-r1-sandbox/cluster-capi/Kptfile
@@ -1,0 +1,22 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: cluster-capi
+  annotations:
+    config.kubernetes.io/local-config: "true"
+upstream:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /cluster-capi
+    ref: cluster-capi/v2
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /cluster-capi
+    ref: cluster-capi/v2
+    commit: 4edc7acc8a3aa3339c5e62206a5a7845de37414d
+info:
+  description: cluster-api package to deploy cluster api

--- a/nephio-r1-sandbox/cluster-capi/README.md
+++ b/nephio-r1-sandbox/cluster-capi/README.md
@@ -1,0 +1,13 @@
+# cluster-capi
+
+## Description
+
+cluster-api package to deploy cluster api
+
+## generate
+
+```
+clusterctl generate provider --core cluster-api:v1.1.5 > cluster-api-core.yaml
+clusterctl generate provider --bootstrap kubeadm:v1.1.5 > cluster-api-bootstrap.yaml
+clusterctl generate provider --control-plane kubeadm:v1.1.5 > cluster-api-control-plane.yaml
+```

--- a/nephio-r1-sandbox/cluster-capi/cluster-api-bootstrap.yaml
+++ b/nephio-r1-sandbox/cluster-capi/cluster-api-bootstrap.yaml
@@ -1,0 +1,4531 @@
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /capi-kubeadm-bootstrap-system
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  name: capi-kubeadm-bootstrap-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|capi-kubeadm-bootstrap-system'
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /kubeadmconfigs.bootstrap.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|kubeadmconfigs.bootstrap.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+    clusterctl.cluster.x-k8s.io: ""
+  name: kubeadmconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmConfig
+    listKind: KubeadmConfigList
+    plural: kubeadmconfigs
+    singular: kubeadmconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+            properties:
+              clusterConfiguration:
+                description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                properties:
+                  apiServer:
+                    description: APIServer contains extra settings for the API server control plane component
+                    properties:
+                      certSANs:
+                        description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                        items:
+                          type: string
+                        type: array
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      timeoutForControlPlane:
+                        description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                        type: string
+                    type: object
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  certificatesDir:
+                    description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                    type: string
+                  clusterName:
+                    description: The cluster name
+                    type: string
+                  controlPlaneEndpoint:
+                    description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                    type: string
+                  controllerManager:
+                    description: ControllerManager contains extra settings for the controller manager control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  dns:
+                    description: DNS defines the options for the DNS add-on installed in the cluster.
+                    properties:
+                      imageRepository:
+                        description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                        type: string
+                      imageTag:
+                        description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        type: string
+                      type:
+                        description: Type defines the DNS add-on to be used
+                        type: string
+                    type: object
+                  etcd:
+                    description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                    properties:
+                      external:
+                        description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                        properties:
+                          caFile:
+                            description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                          certFile:
+                            description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                          endpoints:
+                            description: Endpoints of etcd members. Required for ExternalEtcd.
+                            items:
+                              type: string
+                            type: array
+                          keyFile:
+                            description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                        required:
+                        - caFile
+                        - certFile
+                        - endpoints
+                        - keyFile
+                        type: object
+                      local:
+                        description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                        properties:
+                          dataDir:
+                            description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          peerCertSANs:
+                            description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                            items:
+                              type: string
+                            type: array
+                          serverCertSANs:
+                            description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: FeatureGates enabled by the user.
+                    type: object
+                  imageRepository:
+                    description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  kubernetesVersion:
+                    description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                    type: string
+                  networking:
+                    description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                    properties:
+                      dnsDomain:
+                        description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                        type: string
+                      podSubnet:
+                        description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                        type: string
+                      serviceSubnet:
+                        description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                        type: string
+                    type: object
+                  scheduler:
+                    description: Scheduler contains extra settings for the scheduler control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  useHyperKubeImage:
+                    description: UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images
+                    type: boolean
+                type: object
+              diskSetup:
+                description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: Filesystems specifies the list of file systems to setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: Device specifies the device name
+                          type: string
+                        extraOpts:
+                          description: ExtraOpts defined extra options to add to the command for creating the file system.
+                          items:
+                            type: string
+                          type: array
+                        filesystem:
+                          description: Filesystem specifies the file system type.
+                          type: string
+                        label:
+                          description: Label specifies the file system label to be used. If set to None, no label is used.
+                          type: string
+                        overwrite:
+                          description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                          type: string
+                        replaceFS:
+                          description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      - label
+                      type: object
+                    type: array
+                  partitions:
+                    description: Partitions specifies the list of the partitions to setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: Device is the name of the device.
+                          type: string
+                        layout:
+                          description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    type: array
+                type: object
+              files:
+                description: Files specifies extra files to be passed to user_data upon creation.
+                items:
+                  description: File defines the input for generating write_files in cloud-init.
+                  properties:
+                    content:
+                      description: Content is the actual content of the file.
+                      type: string
+                    contentFrom:
+                      description: ContentFrom is a referenced source of content to populate the file.
+                      properties:
+                        secret:
+                          description: Secret represents a secret that should populate this file.
+                          properties:
+                            key:
+                              description: Key is the key in the secret's data map for this value.
+                              type: string
+                            name:
+                              description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: Encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: Owner specifies the ownership of the file, e.g. "root:root".
+                      type: string
+                    path:
+                      description: Path specifies the full path on disk where to store the file.
+                      type: string
+                    permissions:
+                      description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                      type: string
+                  required:
+                  - path
+                  type: object
+                type: array
+              format:
+                description: Format specifies the output format of the bootstrap data
+                enum:
+                - cloud-config
+                type: string
+              initConfiguration:
+                description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  bootstrapTokens:
+                    description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                    items:
+                      description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                      properties:
+                        description:
+                          description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                          type: string
+                        expires:
+                          description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                          format: date-time
+                          type: string
+                        groups:
+                          description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                          items:
+                            type: string
+                          type: array
+                        token:
+                          description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                          type: string
+                        ttl:
+                          description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                          type: string
+                        usages:
+                          description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - token
+                      type: object
+                    type: array
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  localAPIEndpoint:
+                    description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                    properties:
+                      advertiseAddress:
+                        description: AdvertiseAddress sets the IP address for the API server to advertise.
+                        type: string
+                      bindPort:
+                        description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                        format: int32
+                        type: integer
+                    required:
+                    - advertiseAddress
+                    - bindPort
+                    type: object
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                        type: string
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              joinConfiguration:
+                description: JoinConfiguration is the kubeadm configuration for the join command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  caCertPath:
+                    description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                    type: string
+                  controlPlane:
+                    description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                    properties:
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        required:
+                        - advertiseAddress
+                        - bindPort
+                        type: object
+                    type: object
+                  discovery:
+                    description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                    properties:
+                      bootstrapToken:
+                        description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                        properties:
+                          apiServerEndpoint:
+                            description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                            type: string
+                          caCertHashes:
+                            description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                            items:
+                              type: string
+                            type: array
+                          token:
+                            description: Token is a token used to validate cluster information fetched from the control-plane.
+                            type: string
+                          unsafeSkipCAVerification:
+                            description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                            type: boolean
+                        required:
+                        - token
+                        - unsafeSkipCAVerification
+                        type: object
+                      file:
+                        description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                        properties:
+                          kubeConfigPath:
+                            description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                            type: string
+                        required:
+                        - kubeConfigPath
+                        type: object
+                      timeout:
+                        description: Timeout modifies the discovery timeout
+                        type: string
+                      tlsBootstrapToken:
+                        description: 'TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information TODO: revisit when there is defaulting from k/k'
+                        type: string
+                    type: object
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                        type: string
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              mounts:
+                description: Mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    type: string
+                  type: array
+                type: array
+              ntp:
+                description: NTP specifies NTP configuration
+                properties:
+                  enabled:
+                    description: Enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: Servers specifies which NTP servers to use
+                    items:
+                      type: string
+                    type: array
+                type: object
+              postKubeadmCommands:
+                description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                items:
+                  type: string
+                type: array
+              preKubeadmCommands:
+                description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                items:
+                  type: string
+                type: array
+              useExperimentalRetryJoin:
+                description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                type: boolean
+              users:
+                description: Users specifies extra users to add
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: Gecos specifies the gecos to use for the user
+                      type: string
+                    groups:
+                      description: Groups specifies the additional groups for the user
+                      type: string
+                    homeDir:
+                      description: HomeDir specifies the home directory to use for the user
+                      type: string
+                    inactive:
+                      description: Inactive specifies whether to mark the user as inactive
+                      type: boolean
+                    lockPassword:
+                      description: LockPassword specifies if password login should be disabled
+                      type: boolean
+                    name:
+                      description: Name specifies the user name
+                      type: string
+                    passwd:
+                      description: Passwd specifies a hashed password for the user
+                      type: string
+                    primaryGroup:
+                      description: PrimaryGroup specifies the primary group for the user
+                      type: string
+                    shell:
+                      description: Shell specifies the user's shell
+                      type: string
+                    sshAuthorizedKeys:
+                      description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                      items:
+                        type: string
+                      type: array
+                    sudo:
+                      description: Sudo specifies a sudo role for the user
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              verbosity:
+                description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+            properties:
+              bootstrapData:
+                description: "BootstrapData will be a cloud-init script for now. \n Deprecated: Switch to DataSecretName."
+                format: byte
+                type: string
+              conditions:
+                description: Conditions defines current service state of the KubeadmConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData field is ready to be consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+            properties:
+              clusterConfiguration:
+                description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                properties:
+                  apiServer:
+                    description: APIServer contains extra settings for the API server control plane component
+                    properties:
+                      certSANs:
+                        description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                        items:
+                          type: string
+                        type: array
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      timeoutForControlPlane:
+                        description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                        type: string
+                    type: object
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  certificatesDir:
+                    description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                    type: string
+                  clusterName:
+                    description: The cluster name
+                    type: string
+                  controlPlaneEndpoint:
+                    description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                    type: string
+                  controllerManager:
+                    description: ControllerManager contains extra settings for the controller manager control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  dns:
+                    description: DNS defines the options for the DNS add-on installed in the cluster.
+                    properties:
+                      imageRepository:
+                        description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                        type: string
+                      imageTag:
+                        description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        type: string
+                    type: object
+                  etcd:
+                    description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                    properties:
+                      external:
+                        description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                        properties:
+                          caFile:
+                            description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                          certFile:
+                            description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                          endpoints:
+                            description: Endpoints of etcd members. Required for ExternalEtcd.
+                            items:
+                              type: string
+                            type: array
+                          keyFile:
+                            description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                        required:
+                        - caFile
+                        - certFile
+                        - endpoints
+                        - keyFile
+                        type: object
+                      local:
+                        description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                        properties:
+                          dataDir:
+                            description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          peerCertSANs:
+                            description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                            items:
+                              type: string
+                            type: array
+                          serverCertSANs:
+                            description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: FeatureGates enabled by the user.
+                    type: object
+                  imageRepository:
+                    description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  kubernetesVersion:
+                    description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                    type: string
+                  networking:
+                    description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                    properties:
+                      dnsDomain:
+                        description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                        type: string
+                      podSubnet:
+                        description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                        type: string
+                      serviceSubnet:
+                        description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                        type: string
+                    type: object
+                  scheduler:
+                    description: Scheduler contains extra settings for the scheduler control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              diskSetup:
+                description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: Filesystems specifies the list of file systems to setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: Device specifies the device name
+                          type: string
+                        extraOpts:
+                          description: ExtraOpts defined extra options to add to the command for creating the file system.
+                          items:
+                            type: string
+                          type: array
+                        filesystem:
+                          description: Filesystem specifies the file system type.
+                          type: string
+                        label:
+                          description: Label specifies the file system label to be used. If set to None, no label is used.
+                          type: string
+                        overwrite:
+                          description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                          type: string
+                        replaceFS:
+                          description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      - label
+                      type: object
+                    type: array
+                  partitions:
+                    description: Partitions specifies the list of the partitions to setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: Device is the name of the device.
+                          type: string
+                        layout:
+                          description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    type: array
+                type: object
+              files:
+                description: Files specifies extra files to be passed to user_data upon creation.
+                items:
+                  description: File defines the input for generating write_files in cloud-init.
+                  properties:
+                    content:
+                      description: Content is the actual content of the file.
+                      type: string
+                    contentFrom:
+                      description: ContentFrom is a referenced source of content to populate the file.
+                      properties:
+                        secret:
+                          description: Secret represents a secret that should populate this file.
+                          properties:
+                            key:
+                              description: Key is the key in the secret's data map for this value.
+                              type: string
+                            name:
+                              description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: Encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: Owner specifies the ownership of the file, e.g. "root:root".
+                      type: string
+                    path:
+                      description: Path specifies the full path on disk where to store the file.
+                      type: string
+                    permissions:
+                      description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                      type: string
+                  required:
+                  - path
+                  type: object
+                type: array
+              format:
+                description: Format specifies the output format of the bootstrap data
+                enum:
+                - cloud-config
+                type: string
+              initConfiguration:
+                description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  bootstrapTokens:
+                    description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                    items:
+                      description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                      properties:
+                        description:
+                          description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                          type: string
+                        expires:
+                          description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                          format: date-time
+                          type: string
+                        groups:
+                          description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                          items:
+                            type: string
+                          type: array
+                        token:
+                          description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                          type: string
+                        ttl:
+                          description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                          type: string
+                        usages:
+                          description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - token
+                      type: object
+                    type: array
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  localAPIEndpoint:
+                    description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                    properties:
+                      advertiseAddress:
+                        description: AdvertiseAddress sets the IP address for the API server to advertise.
+                        type: string
+                      bindPort:
+                        description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                        format: int32
+                        type: integer
+                    type: object
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              joinConfiguration:
+                description: JoinConfiguration is the kubeadm configuration for the join command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  caCertPath:
+                    description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                    type: string
+                  controlPlane:
+                    description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                    properties:
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  discovery:
+                    description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                    properties:
+                      bootstrapToken:
+                        description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                        properties:
+                          apiServerEndpoint:
+                            description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                            type: string
+                          caCertHashes:
+                            description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                            items:
+                              type: string
+                            type: array
+                          token:
+                            description: Token is a token used to validate cluster information fetched from the control-plane.
+                            type: string
+                          unsafeSkipCAVerification:
+                            description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                            type: boolean
+                        required:
+                        - token
+                        type: object
+                      file:
+                        description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                        properties:
+                          kubeConfigPath:
+                            description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                            type: string
+                        required:
+                        - kubeConfigPath
+                        type: object
+                      timeout:
+                        description: Timeout modifies the discovery timeout
+                        type: string
+                      tlsBootstrapToken:
+                        description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                        type: string
+                    type: object
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              mounts:
+                description: Mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    type: string
+                  type: array
+                type: array
+              ntp:
+                description: NTP specifies NTP configuration
+                properties:
+                  enabled:
+                    description: Enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: Servers specifies which NTP servers to use
+                    items:
+                      type: string
+                    type: array
+                type: object
+              postKubeadmCommands:
+                description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                items:
+                  type: string
+                type: array
+              preKubeadmCommands:
+                description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                items:
+                  type: string
+                type: array
+              useExperimentalRetryJoin:
+                description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                type: boolean
+              users:
+                description: Users specifies extra users to add
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: Gecos specifies the gecos to use for the user
+                      type: string
+                    groups:
+                      description: Groups specifies the additional groups for the user
+                      type: string
+                    homeDir:
+                      description: HomeDir specifies the home directory to use for the user
+                      type: string
+                    inactive:
+                      description: Inactive specifies whether to mark the user as inactive
+                      type: boolean
+                    lockPassword:
+                      description: LockPassword specifies if password login should be disabled
+                      type: boolean
+                    name:
+                      description: Name specifies the user name
+                      type: string
+                    passwd:
+                      description: Passwd specifies a hashed password for the user
+                      type: string
+                    primaryGroup:
+                      description: PrimaryGroup specifies the primary group for the user
+                      type: string
+                    shell:
+                      description: Shell specifies the user's shell
+                      type: string
+                    sshAuthorizedKeys:
+                      description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                      items:
+                        type: string
+                      type: array
+                    sudo:
+                      description: Sudo specifies a sudo role for the user
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              verbosity:
+                description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the KubeadmConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData field is ready to be consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Time duration since creation of KubeadmConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+            properties:
+              clusterConfiguration:
+                description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                properties:
+                  apiServer:
+                    description: APIServer contains extra settings for the API server control plane component
+                    properties:
+                      certSANs:
+                        description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                        items:
+                          type: string
+                        type: array
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                      timeoutForControlPlane:
+                        description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                        type: string
+                    type: object
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  certificatesDir:
+                    description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                    type: string
+                  clusterName:
+                    description: The cluster name
+                    type: string
+                  controlPlaneEndpoint:
+                    description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                    type: string
+                  controllerManager:
+                    description: ControllerManager contains extra settings for the controller manager control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  dns:
+                    description: DNS defines the options for the DNS add-on installed in the cluster.
+                    properties:
+                      imageRepository:
+                        description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                        type: string
+                      imageTag:
+                        description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        type: string
+                    type: object
+                  etcd:
+                    description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                    properties:
+                      external:
+                        description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                        properties:
+                          caFile:
+                            description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                          certFile:
+                            description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                          endpoints:
+                            description: Endpoints of etcd members. Required for ExternalEtcd.
+                            items:
+                              type: string
+                            type: array
+                          keyFile:
+                            description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                            type: string
+                        required:
+                        - caFile
+                        - certFile
+                        - endpoints
+                        - keyFile
+                        type: object
+                      local:
+                        description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                        properties:
+                          dataDir:
+                            description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          peerCertSANs:
+                            description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                            items:
+                              type: string
+                            type: array
+                          serverCertSANs:
+                            description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: FeatureGates enabled by the user.
+                    type: object
+                  imageRepository:
+                    description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  kubernetesVersion:
+                    description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                    type: string
+                  networking:
+                    description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                    properties:
+                      dnsDomain:
+                        description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                        type: string
+                      podSubnet:
+                        description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                        type: string
+                      serviceSubnet:
+                        description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                        type: string
+                    type: object
+                  scheduler:
+                    description: Scheduler contains extra settings for the scheduler control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                        type: object
+                      extraVolumes:
+                        description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                        items:
+                          description: HostPathMount contains elements describing volumes that are mounted from the host.
+                          properties:
+                            hostPath:
+                              description: HostPath is the path in the host that will be mounted inside the pod.
+                              type: string
+                            mountPath:
+                              description: MountPath is the path inside the pod where hostPath will be mounted.
+                              type: string
+                            name:
+                              description: Name of the volume inside the pod template.
+                              type: string
+                            pathType:
+                              description: PathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: ReadOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              diskSetup:
+                description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: Filesystems specifies the list of file systems to setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: Device specifies the device name
+                          type: string
+                        extraOpts:
+                          description: ExtraOpts defined extra options to add to the command for creating the file system.
+                          items:
+                            type: string
+                          type: array
+                        filesystem:
+                          description: Filesystem specifies the file system type.
+                          type: string
+                        label:
+                          description: Label specifies the file system label to be used. If set to None, no label is used.
+                          type: string
+                        overwrite:
+                          description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                          type: string
+                        replaceFS:
+                          description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      - label
+                      type: object
+                    type: array
+                  partitions:
+                    description: Partitions specifies the list of the partitions to setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: Device is the name of the device.
+                          type: string
+                        layout:
+                          description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    type: array
+                type: object
+              files:
+                description: Files specifies extra files to be passed to user_data upon creation.
+                items:
+                  description: File defines the input for generating write_files in cloud-init.
+                  properties:
+                    content:
+                      description: Content is the actual content of the file.
+                      type: string
+                    contentFrom:
+                      description: ContentFrom is a referenced source of content to populate the file.
+                      properties:
+                        secret:
+                          description: Secret represents a secret that should populate this file.
+                          properties:
+                            key:
+                              description: Key is the key in the secret's data map for this value.
+                              type: string
+                            name:
+                              description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: Encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: Owner specifies the ownership of the file, e.g. "root:root".
+                      type: string
+                    path:
+                      description: Path specifies the full path on disk where to store the file.
+                      type: string
+                    permissions:
+                      description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                      type: string
+                  required:
+                  - path
+                  type: object
+                type: array
+              format:
+                default: cloud-config
+                description: Format specifies the output format of the bootstrap data
+                enum:
+                - cloud-config
+                - ignition
+                type: string
+              ignition:
+                description: Ignition contains Ignition specific configuration.
+                properties:
+                  containerLinuxConfig:
+                    description: ContainerLinuxConfig contains CLC specific configuration.
+                    properties:
+                      additionalConfig:
+                        description: "AdditionalConfig contains additional configuration to be merged with the Ignition configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/"
+                        type: string
+                      strict:
+                        description: Strict controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.
+                        type: boolean
+                    type: object
+                type: object
+              initConfiguration:
+                description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  bootstrapTokens:
+                    description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                    items:
+                      description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                      properties:
+                        description:
+                          description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                          type: string
+                        expires:
+                          description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                          format: date-time
+                          type: string
+                        groups:
+                          description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                          items:
+                            type: string
+                          type: array
+                        token:
+                          description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                          type: string
+                        ttl:
+                          description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                          type: string
+                        usages:
+                          description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - token
+                      type: object
+                    type: array
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  localAPIEndpoint:
+                    description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                    properties:
+                      advertiseAddress:
+                        description: AdvertiseAddress sets the IP address for the API server to advertise.
+                        type: string
+                      bindPort:
+                        description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                        format: int32
+                        type: integer
+                    type: object
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                  patches:
+                    description: Patches contains options related to applying patches to components deployed by kubeadm during "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                    properties:
+                      directory:
+                        description: Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one of "strategic" "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.
+                        type: string
+                    type: object
+                type: object
+              joinConfiguration:
+                description: JoinConfiguration is the kubeadm configuration for the join command
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  caCertPath:
+                    description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                    type: string
+                  controlPlane:
+                    description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                    properties:
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  discovery:
+                    description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                    properties:
+                      bootstrapToken:
+                        description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                        properties:
+                          apiServerEndpoint:
+                            description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                            type: string
+                          caCertHashes:
+                            description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                            items:
+                              type: string
+                            type: array
+                          token:
+                            description: Token is a token used to validate cluster information fetched from the control-plane.
+                            type: string
+                          unsafeSkipCAVerification:
+                            description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                            type: boolean
+                        required:
+                        - token
+                        type: object
+                      file:
+                        description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                        properties:
+                          kubeConfigPath:
+                            description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                            type: string
+                        required:
+                        - kubeConfigPath
+                        type: object
+                      timeout:
+                        description: Timeout modifies the discovery timeout
+                        type: string
+                      tlsBootstrapToken:
+                        description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                        type: string
+                    type: object
+                  kind:
+                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  nodeRegistration:
+                    description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                        type: string
+                      ignorePreflightErrors:
+                        description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                        items:
+                          type: string
+                        type: array
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                        type: string
+                      taints:
+                        description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                        items:
+                          description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                    type: object
+                  patches:
+                    description: Patches contains options related to applying patches to components deployed by kubeadm during "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                    properties:
+                      directory:
+                        description: Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one of "strategic" "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.
+                        type: string
+                    type: object
+                type: object
+              mounts:
+                description: Mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    type: string
+                  type: array
+                type: array
+              ntp:
+                description: NTP specifies NTP configuration
+                properties:
+                  enabled:
+                    description: Enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: Servers specifies which NTP servers to use
+                    items:
+                      type: string
+                    type: array
+                type: object
+              postKubeadmCommands:
+                description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                items:
+                  type: string
+                type: array
+              preKubeadmCommands:
+                description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                items:
+                  type: string
+                type: array
+              useExperimentalRetryJoin:
+                description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                type: boolean
+              users:
+                description: Users specifies extra users to add
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: Gecos specifies the gecos to use for the user
+                      type: string
+                    groups:
+                      description: Groups specifies the additional groups for the user
+                      type: string
+                    homeDir:
+                      description: HomeDir specifies the home directory to use for the user
+                      type: string
+                    inactive:
+                      description: Inactive specifies whether to mark the user as inactive
+                      type: boolean
+                    lockPassword:
+                      description: LockPassword specifies if password login should be disabled
+                      type: boolean
+                    name:
+                      description: Name specifies the user name
+                      type: string
+                    passwd:
+                      description: Passwd specifies a hashed password for the user
+                      type: string
+                    primaryGroup:
+                      description: PrimaryGroup specifies the primary group for the user
+                      type: string
+                    shell:
+                      description: Shell specifies the user's shell
+                      type: string
+                    sshAuthorizedKeys:
+                      description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                      items:
+                        type: string
+                      type: array
+                    sudo:
+                      description: Sudo specifies a sudo role for the user
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              verbosity:
+                description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: KubeadmConfigStatus defines the observed state of KubeadmConfig.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the KubeadmConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: DataSecretName is the name of the secret that stores the bootstrap data script.
+                type: string
+              failureMessage:
+                description: FailureMessage will be set on non-retryable errors
+                type: string
+              failureReason:
+                description: FailureReason will be set on non-retryable errors
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready indicates the BootstrapData field is ready to be consumed
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+    clusterctl.cluster.x-k8s.io: ""
+  name: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-kubeadm-bootstrap-webhook-service
+          namespace: capi-kubeadm-bootstrap-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmConfigTemplate
+    listKind: KubeadmConfigTemplateList
+    plural: kubeadmconfigtemplates
+    singular: kubeadmconfigtemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+            properties:
+              template:
+                description: KubeadmConfigTemplateResource defines the Template structure.
+                properties:
+                  spec:
+                    description: KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          certificatesDir:
+                            description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed in the cluster.
+                            properties:
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              type:
+                                description: Type defines the DNS add-on to be used
+                                type: string
+                            type: object
+                          etcd:
+                            description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                            properties:
+                              external:
+                                description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          kubernetesVersion:
+                            description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                            type: string
+                          networking:
+                            description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          useHyperKubeImage:
+                            description: UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images
+                            type: boolean
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                                  type: string
+                                replaceFS:
+                                  description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions to setup.
+                            items:
+                              description: Partition defines how to create and layout a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data upon creation.
+                        items:
+                          description: File defines the input for generating write_files in cloud-init.
+                          properties:
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file, e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap data
+                        enum:
+                        - cloud-config
+                        type: string
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          bootstrapTokens:
+                            description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            required:
+                            - advertiseAddress
+                            - bindPort
+                            type: object
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for the join command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          caCertPath:
+                            description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                            type: string
+                          controlPlane:
+                            description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - advertiseAddress
+                                - bindPort
+                                type: object
+                            type: object
+                          discovery:
+                            description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                            properties:
+                              bootstrapToken:
+                                description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: Token is a token used to validate cluster information fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                - unsafeSkipCAVerification
+                                type: object
+                              file:
+                                description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: 'TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information TODO: revisit when there is defaulting from k/k'
+                                type: string
+                            type: object
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                type: string
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the user
+                              type: string
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmConfigTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+            properties:
+              template:
+                description: KubeadmConfigTemplateResource defines the Template structure.
+                properties:
+                  spec:
+                    description: KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          certificatesDir:
+                            description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed in the cluster.
+                            properties:
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                          etcd:
+                            description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                            properties:
+                              external:
+                                description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          kubernetesVersion:
+                            description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                            type: string
+                          networking:
+                            description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                                  type: string
+                                replaceFS:
+                                  description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions to setup.
+                            items:
+                              description: Partition defines how to create and layout a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data upon creation.
+                        items:
+                          description: File defines the input for generating write_files in cloud-init.
+                          properties:
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file, e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        description: Format specifies the output format of the bootstrap data
+                        enum:
+                        - cloud-config
+                        type: string
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          bootstrapTokens:
+                            description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for the join command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          caCertPath:
+                            description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                            type: string
+                          controlPlane:
+                            description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                            properties:
+                              bootstrapToken:
+                                description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: Token is a token used to validate cluster information fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                type: object
+                              file:
+                                description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the user
+                              type: string
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmConfigTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmConfigTemplateSpec defines the desired state of KubeadmConfigTemplate.
+            properties:
+              template:
+                description: KubeadmConfigTemplateResource defines the Template structure.
+                properties:
+                  spec:
+                    description: KubeadmConfigSpec defines the desired state of KubeadmConfig. Either ClusterConfiguration and InitConfiguration should be defined or the JoinConfiguration should be defined.
+                    properties:
+                      clusterConfiguration:
+                        description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: APIServer contains extra settings for the API server control plane component
+                            properties:
+                              certSANs:
+                                description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              timeoutForControlPlane:
+                                description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          certificatesDir:
+                            description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                            type: string
+                          clusterName:
+                            description: The cluster name
+                            type: string
+                          controlPlaneEndpoint:
+                            description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                            type: string
+                          controllerManager:
+                            description: ControllerManager contains extra settings for the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                          dns:
+                            description: DNS defines the options for the DNS add-on installed in the cluster.
+                            properties:
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                          etcd:
+                            description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                            properties:
+                              external:
+                                description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                  certFile:
+                                    description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                  endpoints:
+                                    description: Endpoints of etcd members. Required for ExternalEtcd.
+                                    items:
+                                      type: string
+                                    type: array
+                                  keyFile:
+                                    description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                    type: object
+                                  imageRepository:
+                                    description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                  peerCertSANs:
+                                    description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  serverCertSANs:
+                                    description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: FeatureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                            type: string
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          kubernetesVersion:
+                            description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                            type: string
+                          networking:
+                            description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                            properties:
+                              dnsDomain:
+                                description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                                type: string
+                              podSubnet:
+                                description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                type: string
+                              serviceSubnet:
+                                description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                                type: string
+                            type: object
+                          scheduler:
+                            description: Scheduler contains extra settings for the scheduler control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                type: object
+                              extraVolumes:
+                                description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                items:
+                                  description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                  properties:
+                                    hostPath:
+                                      description: HostPath is the path in the host that will be mounted inside the pod.
+                                      type: string
+                                    mountPath:
+                                      description: MountPath is the path inside the pod where hostPath will be mounted.
+                                      type: string
+                                    name:
+                                      description: Name of the volume inside the pod template.
+                                      type: string
+                                    pathType:
+                                      description: PathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: ReadOnly controls write access to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: Filesystems specifies the list of file systems to setup.
+                            items:
+                              description: Filesystem defines the file systems to be created.
+                              properties:
+                                device:
+                                  description: Device specifies the device name
+                                  type: string
+                                extraOpts:
+                                  description: ExtraOpts defined extra options to add to the command for creating the file system.
+                                  items:
+                                    type: string
+                                  type: array
+                                filesystem:
+                                  description: Filesystem specifies the file system type.
+                                  type: string
+                                label:
+                                  description: Label specifies the file system label to be used. If set to None, no label is used.
+                                  type: string
+                                overwrite:
+                                  description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                                  type: string
+                                replaceFS:
+                                  description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              - label
+                              type: object
+                            type: array
+                          partitions:
+                            description: Partitions specifies the list of the partitions to setup.
+                            items:
+                              description: Partition defines how to create and layout a partition.
+                              properties:
+                                device:
+                                  description: Device is the name of the device.
+                                  type: string
+                                layout:
+                                  description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            type: array
+                        type: object
+                      files:
+                        description: Files specifies extra files to be passed to user_data upon creation.
+                        items:
+                          description: File defines the input for generating write_files in cloud-init.
+                          properties:
+                            content:
+                              description: Content is the actual content of the file.
+                              type: string
+                            contentFrom:
+                              description: ContentFrom is a referenced source of content to populate the file.
+                              properties:
+                                secret:
+                                  description: Secret represents a secret that should populate this file.
+                                  properties:
+                                    key:
+                                      description: Key is the key in the secret's data map for this value.
+                                      type: string
+                                    name:
+                                      description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: Encoding specifies the encoding of the file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: Owner specifies the ownership of the file, e.g. "root:root".
+                              type: string
+                            path:
+                              description: Path specifies the full path on disk where to store the file.
+                              type: string
+                            permissions:
+                              description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        type: array
+                      format:
+                        default: cloud-config
+                        description: Format specifies the output format of the bootstrap data
+                        enum:
+                        - cloud-config
+                        - ignition
+                        type: string
+                      ignition:
+                        description: Ignition contains Ignition specific configuration.
+                        properties:
+                          containerLinuxConfig:
+                            description: ContainerLinuxConfig contains CLC specific configuration.
+                            properties:
+                              additionalConfig:
+                                description: "AdditionalConfig contains additional configuration to be merged with the Ignition configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/"
+                                type: string
+                              strict:
+                                description: Strict controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.
+                                type: boolean
+                            type: object
+                        type: object
+                      initConfiguration:
+                        description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          bootstrapTokens:
+                            description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                                  type: string
+                                expires:
+                                  description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                                  items:
+                                    type: string
+                                  type: array
+                                token:
+                                  description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            type: array
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                          patches:
+                            description: Patches contains options related to applying patches to components deployed by kubeadm during "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                            properties:
+                              directory:
+                                description: Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one of "strategic" "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.
+                                type: string
+                            type: object
+                        type: object
+                      joinConfiguration:
+                        description: JoinConfiguration is the kubeadm configuration for the join command
+                        properties:
+                          apiVersion:
+                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            type: string
+                          caCertPath:
+                            description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                            type: string
+                          controlPlane:
+                            description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                            properties:
+                              bootstrapToken:
+                                description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                    type: string
+                                  caCertHashes:
+                                    description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                    items:
+                                      type: string
+                                    type: array
+                                  token:
+                                    description: Token is a token used to validate cluster information fetched from the control-plane.
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                required:
+                                - token
+                                type: object
+                              file:
+                                description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfigPath:
+                                    description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: Timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                type: string
+                            type: object
+                          kind:
+                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          nodeRegistration:
+                            description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                type: string
+                              ignorePreflightErrors:
+                                description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                items:
+                                  type: string
+                                type: array
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                type: string
+                              taints:
+                                description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                items:
+                                  description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                type: array
+                            type: object
+                          patches:
+                            description: Patches contains options related to applying patches to components deployed by kubeadm during "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                            properties:
+                              directory:
+                                description: Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one of "strategic" "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.
+                                type: string
+                            type: object
+                        type: object
+                      mounts:
+                        description: Mounts specifies a list of mount points to be setup.
+                        items:
+                          description: MountPoints defines input for generated mounts in cloud-init.
+                          items:
+                            type: string
+                          type: array
+                        type: array
+                      ntp:
+                        description: NTP specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: Enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: Servers specifies which NTP servers to use
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      preKubeadmCommands:
+                        description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                        items:
+                          type: string
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                        type: boolean
+                      users:
+                        description: Users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user in cloud-init.
+                          properties:
+                            gecos:
+                              description: Gecos specifies the gecos to use for the user
+                              type: string
+                            groups:
+                              description: Groups specifies the additional groups for the user
+                              type: string
+                            homeDir:
+                              description: HomeDir specifies the home directory to use for the user
+                              type: string
+                            inactive:
+                              description: Inactive specifies whether to mark the user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: LockPassword specifies if password login should be disabled
+                              type: boolean
+                            name:
+                              description: Name specifies the user name
+                              type: string
+                            passwd:
+                              description: Passwd specifies a hashed password for the user
+                              type: string
+                            primaryGroup:
+                              description: PrimaryGroup specifies the primary group for the user
+                              type: string
+                            shell:
+                              description: Shell specifies the user's shell
+                              type: string
+                            sshAuthorizedKeys:
+                              description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                              items:
+                                type: string
+                              type: array
+                            sudo:
+                              description: Sudo specifies a sudo role for the user
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      verbosity:
+                        description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: # kpt-merge: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-manager
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-bootstrap-manager
+  namespace: capi-kubeadm-bootstrap-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|capi-kubeadm-bootstrap-system|capi-kubeadm-bootstrap-manager'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: # kpt-merge: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-leader-election-role
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-bootstrap-leader-election-role
+  namespace: capi-kubeadm-bootstrap-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|capi-kubeadm-bootstrap-system|capi-kubeadm-bootstrap-leader-election-role'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /capi-kubeadm-bootstrap-manager-role
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-bootstrap-manager-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|capi-kubeadm-bootstrap-manager-role'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - kubeadmconfigs
+  - kubeadmconfigs/finalizers
+  - kubeadmconfigs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  - machinepools
+  - machinepools/status
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-leader-election-rolebinding
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-bootstrap-leader-election-rolebinding
+  namespace: capi-kubeadm-bootstrap-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|capi-kubeadm-bootstrap-system|capi-kubeadm-bootstrap-leader-election-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-kubeadm-bootstrap-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-bootstrap-manager
+  namespace: capi-kubeadm-bootstrap-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /capi-kubeadm-bootstrap-manager-rolebinding
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-bootstrap-manager-rolebinding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|capi-kubeadm-bootstrap-manager-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-kubeadm-bootstrap-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-bootstrap-manager
+  namespace: capi-kubeadm-bootstrap-system
+---
+apiVersion: v1
+kind: Service
+metadata: # kpt-merge: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-webhook-service
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-bootstrap-webhook-service
+  namespace: capi-kubeadm-bootstrap-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|capi-kubeadm-bootstrap-system|capi-kubeadm-bootstrap-webhook-service'
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-controller-manager
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  name: capi-kubeadm-bootstrap-controller-manager
+  namespace: capi-kubeadm-bootstrap-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|capi-kubeadm-bootstrap-system|capi-kubeadm-bootstrap-controller-manager'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: bootstrap-kubeadm
+      control-plane: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        cluster.x-k8s.io/provider: bootstrap-kubeadm
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --metrics-bind-addr=localhost:8080
+        - --feature-gates=MachinePool=false,KubeadmBootstrapFormatIgnition=false
+        command:
+        - /manager
+        image: k8s.gcr.io/cluster-api/kubeadm-bootstrap-controller:v1.1.5
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        resources: {}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: capi-kubeadm-bootstrap-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capi-kubeadm-bootstrap-webhook-service-cert
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata: # kpt-merge: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-bootstrap-serving-cert
+  namespace: capi-kubeadm-bootstrap-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'cert-manager.io|Certificate|capi-kubeadm-bootstrap-system|capi-kubeadm-bootstrap-serving-cert'
+spec:
+  dnsNames:
+  - capi-kubeadm-bootstrap-webhook-service.capi-kubeadm-bootstrap-system.svc
+  - capi-kubeadm-bootstrap-webhook-service.capi-kubeadm-bootstrap-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capi-kubeadm-bootstrap-selfsigned-issuer
+  secretName: capi-kubeadm-bootstrap-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata: # kpt-merge: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-selfsigned-issuer
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-bootstrap-selfsigned-issuer
+  namespace: capi-kubeadm-bootstrap-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'cert-manager.io|Issuer|capi-kubeadm-bootstrap-system|capi-kubeadm-bootstrap-selfsigned-issuer'
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata: # kpt-merge: /capi-kubeadm-bootstrap-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-bootstrap-system/capi-kubeadm-bootstrap-serving-cert
+    internal.kpt.dev/upstream-identifier: 'admissionregistration.k8s.io|ValidatingWebhookConfiguration|default|capi-kubeadm-bootstrap-validating-webhook-configuration'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: bootstrap-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-bootstrap-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-bootstrap-webhook-service
+      namespace: capi-kubeadm-bootstrap-system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfig
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.kubeadmconfig.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-bootstrap-webhook-service
+      namespace: capi-kubeadm-bootstrap-system
+      path: /validate-bootstrap-cluster-x-k8s-io-v1beta1-kubeadmconfigtemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - bootstrap.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmconfigtemplates
+  sideEffects: None

--- a/nephio-r1-sandbox/cluster-capi/cluster-api-control-plane.yaml
+++ b/nephio-r1-sandbox/cluster-capi/cluster-api-control-plane.yaml
@@ -1,0 +1,4521 @@
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /capi-kubeadm-control-plane-system
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  name: capi-kubeadm-control-plane-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|capi-kubeadm-control-plane-system'
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|kubeadmcontrolplanes.controlplane.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+    clusterctl.cluster.x-k8s.io: ""
+  name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmControlPlane
+    listKind: KubeadmControlPlaneList
+    plural: kubeadmcontrolplanes
+    shortNames:
+    - kcp
+    singular: kubeadmcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: This denotes whether or not the control plane has the uploaded kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Total number of non-terminated machines targeted by this control plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+            properties:
+              infrastructureTemplate:
+                description: InfrastructureTemplate is a required reference to a custom resource offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              kubeadmConfigSpec:
+                description: KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      certificatesDir:
+                        description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed in the cluster.
+                        properties:
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                          type:
+                            description: Type defines the DNS add-on to be used
+                            type: string
+                        type: object
+                      etcd:
+                        description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                        properties:
+                          external:
+                            description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      kubernetesVersion:
+                        description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                        type: string
+                      networking:
+                        description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      useHyperKubeImage:
+                        description: UseHyperKubeImage controls if hyperkube should be used for Kubernetes components instead of their respective separate images
+                        type: boolean
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data upon creation.
+                    items:
+                      description: File defines the input for generating write_files in cloud-init.
+                      properties:
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g. "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    type: string
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      bootstrapTokens:
+                        description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        required:
+                        - advertiseAddress
+                        - bindPort
+                        type: object
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                            items:
+                              description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the join command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      caCertPath:
+                        description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                        type: string
+                      controlPlane:
+                        description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            required:
+                            - advertiseAddress
+                            - bindPort
+                            type: object
+                        type: object
+                      discovery:
+                        description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                        properties:
+                          bootstrapToken:
+                            description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: Token is a token used to validate cluster information fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            - unsafeSkipCAVerification
+                            type: object
+                          file:
+                            description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: 'TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information TODO: revisit when there is defaulting from k/k'
+                            type: string
+                        type: object
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                            type: string
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                            items:
+                              description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                type: string
+              replicas:
+                description: Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rolloutStrategy:
+                description: The RolloutStrategy to use to replace control plane machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of rollout. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              upgradeAfter:
+                description: UpgradeAfter is a field to indicate an upgrade should be performed after the specified time even if no changes have been made to the KubeadmControlPlane
+                format: date-time
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version.
+                type: string
+            required:
+            - infrastructureTemplate
+            - kubeadmConfigSpec
+            - version
+            type: object
+          status:
+            description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a terminal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              initialized:
+                description: Initialized denotes whether or not the control plane has the uploaded kubeadm-config configmap.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the KubeadmControlPlane API Server is ready to receive requests.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane machines.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this control plane (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this control plane that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmControlPlane
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: This denotes whether or not the control plane has the uploaded kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Total number of non-terminated machines targeted by this control plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+            properties:
+              kubeadmConfigSpec:
+                description: KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      certificatesDir:
+                        description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed in the cluster.
+                        properties:
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                        type: object
+                      etcd:
+                        description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                        properties:
+                          external:
+                            description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      kubernetesVersion:
+                        description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                        type: string
+                      networking:
+                        description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data upon creation.
+                    items:
+                      description: File defines the input for generating write_files in cloud-init.
+                      properties:
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g. "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    type: string
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      bootstrapTokens:
+                        description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                            items:
+                              description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the join command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      caCertPath:
+                        description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                        type: string
+                      controlPlane:
+                        description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                        properties:
+                          bootstrapToken:
+                            description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: Token is a token used to validate cluster information fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            type: object
+                          file:
+                            description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            type: string
+                        type: object
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                            items:
+                              description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              machineTemplate:
+                description: MachineTemplate contains information about how machines should be shaped when creating or updating a control plane.
+                properties:
+                  infrastructureRef:
+                    description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  nodeDrainTimeout:
+                    description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                    type: string
+                required:
+                - infrastructureRef
+                type: object
+              replicas:
+                description: Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the KubeadmControlPlane.
+                format: date-time
+                type: string
+              rolloutStrategy:
+                default:
+                  rollingUpdate:
+                    maxSurge: 1
+                  type: RollingUpdate
+                description: The RolloutStrategy to use to replace control plane machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of rollout. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              version:
+                description: Version defines the desired Kubernetes version.
+                type: string
+            required:
+            - kubeadmConfigSpec
+            - machineTemplate
+            - version
+            type: object
+          status:
+            description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a terminal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              initialized:
+                description: Initialized denotes whether or not the control plane has the uploaded kubeadm-config configmap.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the KubeadmControlPlane API Server is ready to receive requests.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane machines.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this control plane (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this control plane that have the desired template spec.
+                format: int32
+                type: integer
+              version:
+                description: Version represents the minimum Kubernetes version for the control plane machines in the cluster.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: This denotes whether or not the control plane has the uploaded kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Total number of non-terminated machines targeted by this control plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: Time duration since creation of KubeadmControlPlane
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+            properties:
+              kubeadmConfigSpec:
+                description: KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.
+                properties:
+                  clusterConfiguration:
+                    description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: APIServer contains extra settings for the API server control plane component
+                        properties:
+                          certSANs:
+                            description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                            items:
+                              type: string
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          timeoutForControlPlane:
+                            description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      certificatesDir:
+                        description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                        type: string
+                      clusterName:
+                        description: The cluster name
+                        type: string
+                      controlPlaneEndpoint:
+                        description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                        type: string
+                      controllerManager:
+                        description: ControllerManager contains extra settings for the controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                      dns:
+                        description: DNS defines the options for the DNS add-on installed in the cluster.
+                        properties:
+                          imageRepository:
+                            description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            type: string
+                          imageTag:
+                            description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            type: string
+                        type: object
+                      etcd:
+                        description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                        properties:
+                          external:
+                            description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                              certFile:
+                                description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                              endpoints:
+                                description: Endpoints of etcd members. Required for ExternalEtcd.
+                                items:
+                                  type: string
+                                type: array
+                              keyFile:
+                                description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                type: object
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                type: string
+                              imageTag:
+                                description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                              peerCertSANs:
+                                description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                items:
+                                  type: string
+                                type: array
+                              serverCertSANs:
+                                description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: FeatureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                        type: string
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      kubernetesVersion:
+                        description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                        type: string
+                      networking:
+                        description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                        properties:
+                          dnsDomain:
+                            description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                            type: string
+                          podSubnet:
+                            description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            type: string
+                          serviceSubnet:
+                            description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                            type: string
+                        type: object
+                      scheduler:
+                        description: Scheduler contains extra settings for the scheduler control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                            type: object
+                          extraVolumes:
+                            description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                            items:
+                              description: HostPathMount contains elements describing volumes that are mounted from the host.
+                              properties:
+                                hostPath:
+                                  description: HostPath is the path in the host that will be mounted inside the pod.
+                                  type: string
+                                mountPath:
+                                  description: MountPath is the path inside the pod where hostPath will be mounted.
+                                  type: string
+                                name:
+                                  description: Name of the volume inside the pod template.
+                                  type: string
+                                pathType:
+                                  description: PathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: ReadOnly controls write access to the volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: Filesystems specifies the list of file systems to setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: Device specifies the device name
+                              type: string
+                            extraOpts:
+                              description: ExtraOpts defined extra options to add to the command for creating the file system.
+                              items:
+                                type: string
+                              type: array
+                            filesystem:
+                              description: Filesystem specifies the file system type.
+                              type: string
+                            label:
+                              description: Label specifies the file system label to be used. If set to None, no label is used.
+                              type: string
+                            overwrite:
+                              description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                              type: string
+                            replaceFS:
+                              description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          - label
+                          type: object
+                        type: array
+                      partitions:
+                        description: Partitions specifies the list of the partitions to setup.
+                        items:
+                          description: Partition defines how to create and layout a partition.
+                          properties:
+                            device:
+                              description: Device is the name of the device.
+                              type: string
+                            layout:
+                              description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        type: array
+                    type: object
+                  files:
+                    description: Files specifies extra files to be passed to user_data upon creation.
+                    items:
+                      description: File defines the input for generating write_files in cloud-init.
+                      properties:
+                        content:
+                          description: Content is the actual content of the file.
+                          type: string
+                        contentFrom:
+                          description: ContentFrom is a referenced source of content to populate the file.
+                          properties:
+                            secret:
+                              description: Secret represents a secret that should populate this file.
+                              properties:
+                                key:
+                                  description: Key is the key in the secret's data map for this value.
+                                  type: string
+                                name:
+                                  description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: Encoding specifies the encoding of the file contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: Owner specifies the ownership of the file, e.g. "root:root".
+                          type: string
+                        path:
+                          description: Path specifies the full path on disk where to store the file.
+                          type: string
+                        permissions:
+                          description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    type: array
+                  format:
+                    default: cloud-config
+                    description: Format specifies the output format of the bootstrap data
+                    enum:
+                    - cloud-config
+                    - ignition
+                    type: string
+                  ignition:
+                    description: Ignition contains Ignition specific configuration.
+                    properties:
+                      containerLinuxConfig:
+                        description: ContainerLinuxConfig contains CLC specific configuration.
+                        properties:
+                          additionalConfig:
+                            description: "AdditionalConfig contains additional configuration to be merged with the Ignition configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/"
+                            type: string
+                          strict:
+                            description: Strict controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.
+                            type: boolean
+                        type: object
+                    type: object
+                  initConfiguration:
+                    description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      bootstrapTokens:
+                        description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                              type: string
+                            expires:
+                              description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                              items:
+                                type: string
+                              type: array
+                            token:
+                              description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        type: array
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      localAPIEndpoint:
+                        description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: AdvertiseAddress sets the IP address for the API server to advertise.
+                            type: string
+                          bindPort:
+                            description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                            items:
+                              description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                      patches:
+                        description: Patches contains options related to applying patches to components deployed by kubeadm during "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                        properties:
+                          directory:
+                            description: Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one of "strategic" "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.
+                            type: string
+                        type: object
+                    type: object
+                  joinConfiguration:
+                    description: JoinConfiguration is the kubeadm configuration for the join command
+                    properties:
+                      apiVersion:
+                        description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        type: string
+                      caCertPath:
+                        description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                        type: string
+                      controlPlane:
+                        description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                type: string
+                              bindPort:
+                                description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                        properties:
+                          bootstrapToken:
+                            description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                type: string
+                              caCertHashes:
+                                description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                items:
+                                  type: string
+                                type: array
+                              token:
+                                description: Token is a token used to validate cluster information fetched from the control-plane.
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            required:
+                            - token
+                            type: object
+                          file:
+                            description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfigPath:
+                                description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: Timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            type: string
+                        type: object
+                      kind:
+                        description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      nodeRegistration:
+                        description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                            type: string
+                          ignorePreflightErrors:
+                            description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                            items:
+                              type: string
+                            type: array
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                            type: string
+                          taints:
+                            description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                            items:
+                              description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied to a node.
+                                  type: string
+                                timeAdded:
+                                  description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            type: array
+                        type: object
+                      patches:
+                        description: Patches contains options related to applying patches to components deployed by kubeadm during "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                        properties:
+                          directory:
+                            description: Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one of "strategic" "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.
+                            type: string
+                        type: object
+                    type: object
+                  mounts:
+                    description: Mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts in cloud-init.
+                      items:
+                        type: string
+                      type: array
+                    type: array
+                  ntp:
+                    description: NTP specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: Enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: Servers specifies which NTP servers to use
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  preKubeadmCommands:
+                    description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                    items:
+                      type: string
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                    type: boolean
+                  users:
+                    description: Users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in cloud-init.
+                      properties:
+                        gecos:
+                          description: Gecos specifies the gecos to use for the user
+                          type: string
+                        groups:
+                          description: Groups specifies the additional groups for the user
+                          type: string
+                        homeDir:
+                          description: HomeDir specifies the home directory to use for the user
+                          type: string
+                        inactive:
+                          description: Inactive specifies whether to mark the user as inactive
+                          type: boolean
+                        lockPassword:
+                          description: LockPassword specifies if password login should be disabled
+                          type: boolean
+                        name:
+                          description: Name specifies the user name
+                          type: string
+                        passwd:
+                          description: Passwd specifies a hashed password for the user
+                          type: string
+                        primaryGroup:
+                          description: PrimaryGroup specifies the primary group for the user
+                          type: string
+                        shell:
+                          description: Shell specifies the user's shell
+                          type: string
+                        sshAuthorizedKeys:
+                          description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                          items:
+                            type: string
+                          type: array
+                        sudo:
+                          description: Sudo specifies a sudo role for the user
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  verbosity:
+                    description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              machineTemplate:
+                description: MachineTemplate contains information about how machines should be shaped when creating or updating a control plane.
+                properties:
+                  infrastructureRef:
+                    description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  nodeDrainTimeout:
+                    description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                    type: string
+                required:
+                - infrastructureRef
+                type: object
+              replicas:
+                description: Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the KubeadmControlPlane.
+                format: date-time
+                type: string
+              rolloutStrategy:
+                default:
+                  rollingUpdate:
+                    maxSurge: 1
+                  type: RollingUpdate
+                description: The RolloutStrategy to use to replace control plane machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of rollout. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              version:
+                description: Version defines the desired Kubernetes version.
+                type: string
+            required:
+            - kubeadmConfigSpec
+            - machineTemplate
+            - version
+            type: object
+          status:
+            description: KubeadmControlPlaneStatus defines the observed state of KubeadmControlPlane.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: ErrorMessage indicates that there is a terminal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a terminal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              initialized:
+                description: Initialized denotes whether or not the control plane has the uploaded kubeadm-config configmap.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: Ready denotes that the KubeadmControlPlane API Server is ready to receive requests.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane machines.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this control plane (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the label selector in string format to avoid introspection by clients, and is used to provide the CRD-based integration for the scale subresource and additional integrations for things like kubectl describe.. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this control plane. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet ready or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this control plane that have the desired template spec.
+                format: int32
+                type: integer
+              version:
+                description: Version represents the minimum Kubernetes version for the control plane machines in the cluster.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    cluster.x-k8s.io/v1alpha3: v1alpha3
+    cluster.x-k8s.io/v1alpha4: v1alpha4
+    cluster.x-k8s.io/v1beta1: v1beta1
+    clusterctl.cluster.x-k8s.io: ""
+  name: kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-kubeadm-control-plane-webhook-service
+          namespace: capi-kubeadm-control-plane-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmControlPlaneTemplate
+    listKind: KubeadmControlPlaneTemplateList
+    plural: kubeadmcontrolplanetemplates
+    singular: kubeadmcontrolplanetemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmControlPlaneTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneTemplateSpec defines the desired state of KubeadmControlPlaneTemplate.
+            properties:
+              template:
+                description: KubeadmControlPlaneTemplateResource describes the data needed to create a KubeadmControlPlane from a template.
+                properties:
+                  spec:
+                    description: KubeadmControlPlaneSpec defines the desired state of KubeadmControlPlane.
+                    properties:
+                      kubeadmConfigSpec:
+                        description: KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.
+                        properties:
+                          clusterConfiguration:
+                            description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: APIServer contains extra settings for the API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              certificatesDir:
+                                description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                                type: string
+                              controllerManager:
+                                description: ControllerManager contains extra settings for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: DNS defines the options for the DNS add-on installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                type: object
+                              etcd:
+                                description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                                properties:
+                                  external:
+                                    description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: Endpoints of etcd members. Required for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                        type: object
+                                      imageRepository:
+                                        description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: FeatureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                                type: string
+                              kind:
+                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              kubernetesVersion:
+                                description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                                type: string
+                              networking:
+                                description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                                properties:
+                                  dnsDomain:
+                                    description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: Scheduler contains extra settings for the scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: Filesystems specifies the list of file systems to setup.
+                                items:
+                                  description: Filesystem defines the file systems to be created.
+                                  properties:
+                                    device:
+                                      description: Device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: ExtraOpts defined extra options to add to the command for creating the file system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: Filesystem specifies the file system type.
+                                      type: string
+                                    label:
+                                      description: Label specifies the file system label to be used. If set to None, no label is used.
+                                      type: string
+                                    overwrite:
+                                      description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: Partitions specifies the list of the partitions to setup.
+                                items:
+                                  description: Partition defines how to create and layout a partition.
+                                  properties:
+                                    device:
+                                      description: Device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: Files specifies extra files to be passed to user_data upon creation.
+                            items:
+                              description: File defines the input for generating write_files in cloud-init.
+                              properties:
+                                content:
+                                  description: Content is the actual content of the file.
+                                  type: string
+                                contentFrom:
+                                  description: ContentFrom is a referenced source of content to populate the file.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should populate this file.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: Encoding specifies the encoding of the file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: Owner specifies the ownership of the file, e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: Path specifies the full path on disk where to store the file.
+                                  type: string
+                                permissions:
+                                  description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            description: Format specifies the output format of the bootstrap data
+                            enum:
+                            - cloud-config
+                            type: string
+                          initConfiguration:
+                            description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              bootstrapTokens:
+                                description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                    items:
+                                      description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          joinConfiguration:
+                            description: JoinConfiguration is the kubeadm configuration for the join command
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              caCertPath:
+                                description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                                type: string
+                              controlPlane:
+                                description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                                properties:
+                                  bootstrapToken:
+                                    description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: Token is a token used to validate cluster information fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    type: object
+                                  file:
+                                    description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfigPath:
+                                        description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: Timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                    type: string
+                                type: object
+                              kind:
+                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              nodeRegistration:
+                                description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                    items:
+                                      description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          mounts:
+                            description: Mounts specifies a list of mount points to be setup.
+                            items:
+                              description: MountPoints defines input for generated mounts in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: NTP specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether NTP should be enabled
+                                type: boolean
+                              servers:
+                                description: Servers specifies which NTP servers to use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                            type: boolean
+                          users:
+                            description: Users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated user in cloud-init.
+                              properties:
+                                gecos:
+                                  description: Gecos specifies the gecos to use for the user
+                                  type: string
+                                groups:
+                                  description: Groups specifies the additional groups for the user
+                                  type: string
+                                homeDir:
+                                  description: HomeDir specifies the home directory to use for the user
+                                  type: string
+                                inactive:
+                                  description: Inactive specifies whether to mark the user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: LockPassword specifies if password login should be disabled
+                                  type: boolean
+                                name:
+                                  description: Name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: Passwd specifies a hashed password for the user
+                                  type: string
+                                primaryGroup:
+                                  description: PrimaryGroup specifies the primary group for the user
+                                  type: string
+                                shell:
+                                  description: Shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: Sudo specifies a sudo role for the user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                      machineTemplate:
+                        description: MachineTemplate contains information about how machines should be shaped when creating or updating a control plane.
+                        properties:
+                          infrastructureRef:
+                            description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          metadata:
+                            description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                type: object
+                            type: object
+                          nodeDrainTimeout:
+                            description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                            type: string
+                        required:
+                        - infrastructureRef
+                        type: object
+                      replicas:
+                        description: Number of desired machines. Defaults to 1. When stacked etcd is used only odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members). This is a pointer to distinguish between explicit zero and not specified.
+                        format: int32
+                        type: integer
+                      rolloutAfter:
+                        description: RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the KubeadmControlPlane.
+                        format: date-time
+                        type: string
+                      rolloutStrategy:
+                        default:
+                          rollingUpdate:
+                            maxSurge: 1
+                          type: RollingUpdate
+                        description: The RolloutStrategy to use to replace control plane machines with new ones.
+                        properties:
+                          rollingUpdate:
+                            description: Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.'
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of rollout. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                            type: string
+                        type: object
+                      version:
+                        description: Version defines the desired Kubernetes version.
+                        type: string
+                    required:
+                    - kubeadmConfigSpec
+                    - machineTemplate
+                    - version
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmControlPlaneTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KubeadmControlPlaneTemplateSpec defines the desired state of KubeadmControlPlaneTemplate.
+            properties:
+              template:
+                description: KubeadmControlPlaneTemplateResource describes the data needed to create a KubeadmControlPlane from a template.
+                properties:
+                  spec:
+                    description: 'KubeadmControlPlaneTemplateResourceSpec defines the desired state of KubeadmControlPlane. NOTE: KubeadmControlPlaneTemplateResourceSpec is similar to KubeadmControlPlaneSpec but omits Replicas and Version fields. These fields do not make sense on the KubeadmControlPlaneTemplate, because they are calculated by the Cluster topology reconciler during reconciliation and thus cannot be configured on the KubeadmControlPlaneTemplate.'
+                    properties:
+                      kubeadmConfigSpec:
+                        description: KubeadmConfigSpec is a KubeadmConfigSpec to use for initializing and joining machines to the control plane.
+                        properties:
+                          clusterConfiguration:
+                            description: ClusterConfiguration along with InitConfiguration are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: APIServer contains extra settings for the API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: CertSANs sets extra Subject Alternative Names for the API Server signing cert.
+                                    items:
+                                      type: string
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: TimeoutForControlPlane controls the timeout that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              certificatesDir:
+                                description: 'CertificatesDir specifies where to store or look for all required certificates. NB: if not provided, this will default to `/etc/kubernetes/pki`'
+                                type: string
+                              clusterName:
+                                description: The cluster name
+                                type: string
+                              controlPlaneEndpoint:
+                                description: 'ControlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port. In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort are used; in case the ControlPlaneEndpoint is specified but without a TCP port, the BindPort is used. Possible usages are: e.g. In a cluster with more than one control plane instances, this field should be assigned the address of the external load balancer in front of the control plane instances. e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint could be used for assigning a stable DNS to the control plane. NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.'
+                                type: string
+                              controllerManager:
+                                description: ControllerManager contains extra settings for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                              dns:
+                                description: DNS defines the options for the DNS add-on installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    type: string
+                                  imageTag:
+                                    description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    type: string
+                                type: object
+                              etcd:
+                                description: 'Etcd holds configuration for etcd. NB: This value defaults to a Local (stacked) etcd'
+                                properties:
+                                  external:
+                                    description: External describes how to connect to an external etcd cluster Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: CAFile is an SSL Certificate Authority file used to secure etcd communication. Required if using a TLS connection.
+                                        type: string
+                                      certFile:
+                                        description: CertFile is an SSL certification file used to secure etcd communication. Required if using a TLS connection.
+                                        type: string
+                                      endpoints:
+                                        description: Endpoints of etcd members. Required for ExternalEtcd.
+                                        items:
+                                          type: string
+                                        type: array
+                                      keyFile:
+                                        description: KeyFile is an SSL key file used to secure etcd communication. Required if using a TLS connection.
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: Local provides configuration knobs for configuring the local etcd instance Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: DataDir is the directory etcd will place its data. Defaults to "/var/lib/etcd".
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: ExtraArgs are extra arguments provided to the etcd binary when run inside a static pod.
+                                        type: object
+                                      imageRepository:
+                                        description: ImageRepository sets the container registry to pull images from. if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        type: string
+                                      imageTag:
+                                        description: ImageTag allows to specify a tag for the image. In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        type: string
+                                      peerCertSANs:
+                                        description: PeerCertSANs sets extra Subject Alternative Names for the etcd peer signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serverCertSANs:
+                                        description: ServerCertSANs sets extra Subject Alternative Names for the etcd server signing cert.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: FeatureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: ImageRepository sets the container registry to pull images from. If empty, `k8s.gcr.io` will be used by default; in case of kubernetes version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`) `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components and for kube-proxy, while `k8s.gcr.io` will be used for all the other images.
+                                type: string
+                              kind:
+                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              kubernetesVersion:
+                                description: 'KubernetesVersion is the target version of the control plane. NB: This value defaults to the Machine object spec.version'
+                                type: string
+                              networking:
+                                description: 'Networking holds configuration for the networking topology of the cluster. NB: This value defaults to the Cluster object spec.clusterNetwork.'
+                                properties:
+                                  dnsDomain:
+                                    description: DNSDomain is the dns domain used by k8s services. Defaults to "cluster.local".
+                                    type: string
+                                  podSubnet:
+                                    description: PodSubnet is the subnet used by pods. If unset, the API server will not allocate CIDR ranges for every node. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    type: string
+                                  serviceSubnet:
+                                    description: ServiceSubnet is the subnet used by k8s services. Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or to "10.96.0.0/12" if that's unset.
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: Scheduler contains extra settings for the scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'ExtraArgs is an extra set of flags to pass to the control plane component. TODO: This is temporary and ideally we would like to switch all components to use ComponentConfig + ConfigMaps.'
+                                    type: object
+                                  extraVolumes:
+                                    description: ExtraVolumes is an extra set of host volumes, mounted to the control plane component.
+                                    items:
+                                      description: HostPathMount contains elements describing volumes that are mounted from the host.
+                                      properties:
+                                        hostPath:
+                                          description: HostPath is the path in the host that will be mounted inside the pod.
+                                          type: string
+                                        mountPath:
+                                          description: MountPath is the path inside the pod where hostPath will be mounted.
+                                          type: string
+                                        name:
+                                          description: Name of the volume inside the pod template.
+                                          type: string
+                                        pathType:
+                                          description: PathType is the type of the HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: ReadOnly controls write access to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: DiskSetup specifies options for the creation of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: Filesystems specifies the list of file systems to setup.
+                                items:
+                                  description: Filesystem defines the file systems to be created.
+                                  properties:
+                                    device:
+                                      description: Device specifies the device name
+                                      type: string
+                                    extraOpts:
+                                      description: ExtraOpts defined extra options to add to the command for creating the file system.
+                                      items:
+                                        type: string
+                                      type: array
+                                    filesystem:
+                                      description: Filesystem specifies the file system type.
+                                      type: string
+                                    label:
+                                      description: Label specifies the file system label to be used. If set to None, no label is used.
+                                      type: string
+                                    overwrite:
+                                      description: Overwrite defines whether or not to overwrite any existing filesystem. If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'Partition specifies the partition to use. The valid options are: "auto|any", "auto", "any", "none", and <NUM>, where NUM is the actual partition number.'
+                                      type: string
+                                    replaceFS:
+                                      description: 'ReplaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>. NOTE: unless you define a label, this requires the use of the ''any'' partition directive.'
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  - label
+                                  type: object
+                                type: array
+                              partitions:
+                                description: Partitions specifies the list of the partitions to setup.
+                                items:
+                                  description: Partition defines how to create and layout a partition.
+                                  properties:
+                                    device:
+                                      description: Device is the name of the device.
+                                      type: string
+                                    layout:
+                                      description: Layout specifies the device layout. If it is true, a single partition will be created for the entire device. When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: Overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device. Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: 'TableType specifies the tupe of partition table. The following are supported: ''mbr'': default and setups a MS-DOS partition table ''gpt'': setups a GPT partition table'
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                type: array
+                            type: object
+                          files:
+                            description: Files specifies extra files to be passed to user_data upon creation.
+                            items:
+                              description: File defines the input for generating write_files in cloud-init.
+                              properties:
+                                content:
+                                  description: Content is the actual content of the file.
+                                  type: string
+                                contentFrom:
+                                  description: ContentFrom is a referenced source of content to populate the file.
+                                  properties:
+                                    secret:
+                                      description: Secret represents a secret that should populate this file.
+                                      properties:
+                                        key:
+                                          description: Key is the key in the secret's data map for this value.
+                                          type: string
+                                        name:
+                                          description: Name of the secret in the KubeadmBootstrapConfig's namespace to use.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: Encoding specifies the encoding of the file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: Owner specifies the ownership of the file, e.g. "root:root".
+                                  type: string
+                                path:
+                                  description: Path specifies the full path on disk where to store the file.
+                                  type: string
+                                permissions:
+                                  description: Permissions specifies the permissions to assign to the file, e.g. "0640".
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            type: array
+                          format:
+                            default: cloud-config
+                            description: Format specifies the output format of the bootstrap data
+                            enum:
+                            - cloud-config
+                            - ignition
+                            type: string
+                          ignition:
+                            description: Ignition contains Ignition specific configuration.
+                            properties:
+                              containerLinuxConfig:
+                                description: ContainerLinuxConfig contains CLC specific configuration.
+                                properties:
+                                  additionalConfig:
+                                    description: "AdditionalConfig contains additional configuration to be merged with the Ignition configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging \n The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/"
+                                    type: string
+                                  strict:
+                                    description: Strict controls if AdditionalConfig should be strictly parsed. If so, warnings are treated as errors.
+                                    type: boolean
+                                type: object
+                            type: object
+                          initConfiguration:
+                            description: InitConfiguration along with ClusterConfiguration are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              bootstrapTokens:
+                                description: BootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create. This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: Description sets a human-friendly message why this token exists and what it's used for, so other administrators can know its purpose.
+                                      type: string
+                                    expires:
+                                      description: Expires specifies the timestamp when this token expires. Defaults to being set dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: Groups specifies the extra groups that this token will authenticate as when/if used for authentication
+                                      items:
+                                        type: string
+                                      type: array
+                                    token:
+                                      description: Token is used for establishing bidirectional trust between nodes and control-planes. Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: TTL defines the time to live for this token. Defaults to 24h. Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: Usages describes the ways in which this token can be used. Can by default be used for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                type: array
+                              kind:
+                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              localAPIEndpoint:
+                                description: LocalAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                    type: string
+                                  bindPort:
+                                    description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                    items:
+                                      description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                              patches:
+                                description: Patches contains options related to applying patches to components deployed by kubeadm during "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one of "strategic" "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.
+                                    type: string
+                                type: object
+                            type: object
+                          joinConfiguration:
+                            description: JoinConfiguration is the kubeadm configuration for the join command
+                            properties:
+                              apiVersion:
+                                description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                type: string
+                              caCertPath:
+                                description: 'CACertPath is the path to the SSL certificate authority used to secure comunications between node and control-plane. Defaults to "/etc/kubernetes/pki/ca.crt". TODO: revisit when there is defaulting from k/k'
+                                type: string
+                              controlPlane:
+                                description: ControlPlane defines the additional control plane instance to be deployed on the joining node. If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: LocalAPIEndpoint represents the endpoint of the API server instance to be deployed on this node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: AdvertiseAddress sets the IP address for the API server to advertise.
+                                        type: string
+                                      bindPort:
+                                        description: BindPort sets the secure port for the API Server to bind to. Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: 'Discovery specifies the options for the kubelet to use during the TLS Bootstrap process TODO: revisit when there is defaulting from k/k'
+                                properties:
+                                  bootstrapToken:
+                                    description: BootstrapToken is used to set the options for bootstrap token based discovery BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: APIServerEndpoint is an IP or domain name to the API server from which info will be fetched.
+                                        type: string
+                                      caCertHashes:
+                                        description: 'CACertHashes specifies a set of public key pins to verify when token-based discovery is used. The root CA found during discovery must match one of these values. Specifying an empty set disables root CA pinning, which can be unsafe. Each hash is specified as "<type>:<value>", where the only currently supported type is "sha256". This is a hex-encoded SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded ASN.1. These hashes can be calculated using, for example, OpenSSL: openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex'
+                                        items:
+                                          type: string
+                                        type: array
+                                      token:
+                                        description: Token is a token used to validate cluster information fetched from the control-plane.
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: UnsafeSkipCAVerification allows token-based discovery without CA verification via CACertHashes. This can weaken the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    required:
+                                    - token
+                                    type: object
+                                  file:
+                                    description: File is used to specify a file or URL to a kubeconfig file from which to load cluster information BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfigPath:
+                                        description: KubeConfigPath is used to specify the actual file path or URL to the kubeconfig file from which to load cluster information
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: Timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: TLSBootstrapToken is a token used for TLS bootstrapping. If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden. If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                    type: string
+                                type: object
+                              kind:
+                                description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              nodeRegistration:
+                                description: NodeRegistration holds fields that relate to registering the new control-plane node to the cluster. When used in the context of control plane nodes, NodeRegistration should remain consistent across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: CRISocket is used to retrieve container runtime info. This information will be annotated to the Node API object, for later re-use
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered.
+                                    items:
+                                      type: string
+                                    type: array
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: Name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation. This field is also used in the CommonName field of the kubelet's client certificate to the API server. Defaults to the hostname of the node if not provided.
+                                    type: string
+                                  taints:
+                                    description: 'Taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process it will be defaulted to []v1.Taint{''node-role.kubernetes.io/master=""''}. If you don''t want to taint your control-plane node, set this field to an empty slice, i.e. `taints: {}` in the YAML file. This field is solely used for Node registration.'
+                                    items:
+                                      description: The node this Taint is attached to has the "effect" on any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    type: array
+                                type: object
+                              patches:
+                                description: Patches contains options related to applying patches to components deployed by kubeadm during "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: Directory is a path to a directory that contains files named "target[suffix][+patchtype].extension". For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one of "strategic" "merge" or "json" and they match the patch formats supported by kubectl. The default "patchtype" is "strategic". "extension" must be either "json" or "yaml". "suffix" is an optional string that can be used to determine which patches are applied first alpha-numerically. These files can be written into the target directory via KubeadmConfig.Files which specifies additional files to be created on the machine, either with content inline or by referencing a secret.
+                                    type: string
+                                type: object
+                            type: object
+                          mounts:
+                            description: Mounts specifies a list of mount points to be setup.
+                            items:
+                              description: MountPoints defines input for generated mounts in cloud-init.
+                              items:
+                                type: string
+                              type: array
+                            type: array
+                          ntp:
+                            description: NTP specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: Enabled specifies whether NTP should be enabled
+                                type: boolean
+                              servers:
+                                description: Servers specifies which NTP servers to use
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: PostKubeadmCommands specifies extra commands to run after kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          preKubeadmCommands:
+                            description: PreKubeadmCommands specifies extra commands to run before kubeadm runs
+                            items:
+                              type: string
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: "UseExperimentalRetryJoin replaces a basic kubeadm command with a shell script with retries for joins. \n This is meant to be an experimental temporary workaround on some environments where joins fail due to timing (and other issues). The long term goal is to add retries to kubeadm proper and use that functionality. \n This will add about 40KB to userdata \n For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055."
+                            type: boolean
+                          users:
+                            description: Users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated user in cloud-init.
+                              properties:
+                                gecos:
+                                  description: Gecos specifies the gecos to use for the user
+                                  type: string
+                                groups:
+                                  description: Groups specifies the additional groups for the user
+                                  type: string
+                                homeDir:
+                                  description: HomeDir specifies the home directory to use for the user
+                                  type: string
+                                inactive:
+                                  description: Inactive specifies whether to mark the user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: LockPassword specifies if password login should be disabled
+                                  type: boolean
+                                name:
+                                  description: Name specifies the user name
+                                  type: string
+                                passwd:
+                                  description: Passwd specifies a hashed password for the user
+                                  type: string
+                                primaryGroup:
+                                  description: PrimaryGroup specifies the primary group for the user
+                                  type: string
+                                shell:
+                                  description: Shell specifies the user's shell
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: SSHAuthorizedKeys specifies a list of ssh authorized keys for the user
+                                  items:
+                                    type: string
+                                  type: array
+                                sudo:
+                                  description: Sudo specifies a sudo role for the user
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          verbosity:
+                            description: Verbosity is the number for the kubeadm log level verbosity. It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                      machineTemplate:
+                        description: MachineTemplate contains information about how machines should be shaped when creating or updating a control plane.
+                        properties:
+                          nodeDrainTimeout:
+                            description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                            type: string
+                        type: object
+                      rolloutAfter:
+                        description: RolloutAfter is a field to indicate a rollout should be performed after the specified time even if no changes have been made to the KubeadmControlPlane.
+                        format: date-time
+                        type: string
+                      rolloutStrategy:
+                        default:
+                          rollingUpdate:
+                            maxSurge: 1
+                          type: RollingUpdate
+                        description: The RolloutStrategy to use to replace control plane machines with new ones.
+                        properties:
+                          rollingUpdate:
+                            description: Rolling update config params. Present only if RolloutStrategyType = RollingUpdate.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: 'The maximum number of control planes that can be scheduled above or under the desired number of control planes. Value can be an absolute number 1 or 0. Defaults to 1. Example: when this is set to 1, the control plane can be scaled up immediately when the rolling update starts.'
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: Type of rollout. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                            type: string
+                        type: object
+                    required:
+                    - kubeadmConfigSpec
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: # kpt-merge: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-manager
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-control-plane-manager
+  namespace: capi-kubeadm-control-plane-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|capi-kubeadm-control-plane-system|capi-kubeadm-control-plane-manager'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: # kpt-merge: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-leader-election-role
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-control-plane-leader-election-role
+  namespace: capi-kubeadm-control-plane-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|capi-kubeadm-control-plane-system|capi-kubeadm-control-plane-leader-election-role'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /capi-kubeadm-control-plane-aggregated-manager-role
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-control-plane-aggregated-manager-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|capi-kubeadm-control-plane-aggregated-manager-role'
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /capi-kubeadm-control-plane-manager-role
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+    kubeadm.controlplane.cluster.x-k8s.io/aggregate-to-manager: "true"
+  name: capi-kubeadm-control-plane-manager-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|capi-kubeadm-control-plane-manager-role'
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-leader-election-rolebinding
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-control-plane-leader-election-rolebinding
+  namespace: capi-kubeadm-control-plane-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|capi-kubeadm-control-plane-system|capi-kubeadm-control-plane-leader-election-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-kubeadm-control-plane-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-control-plane-manager
+  namespace: capi-kubeadm-control-plane-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /capi-kubeadm-control-plane-manager-rolebinding
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-control-plane-manager-rolebinding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|capi-kubeadm-control-plane-manager-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-kubeadm-control-plane-aggregated-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-kubeadm-control-plane-manager
+  namespace: capi-kubeadm-control-plane-system
+---
+apiVersion: v1
+kind: Service
+metadata: # kpt-merge: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-webhook-service
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-control-plane-webhook-service
+  namespace: capi-kubeadm-control-plane-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|capi-kubeadm-control-plane-system|capi-kubeadm-control-plane-webhook-service'
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-controller-manager
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  name: capi-kubeadm-control-plane-controller-manager
+  namespace: capi-kubeadm-control-plane-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|capi-kubeadm-control-plane-system|capi-kubeadm-control-plane-controller-manager'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: control-plane-kubeadm
+      control-plane: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        cluster.x-k8s.io/provider: control-plane-kubeadm
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --metrics-bind-addr=localhost:8080
+        - --feature-gates=ClusterTopology=true,KubeadmBootstrapFormatIgnition=true
+        command:
+        - /manager
+        image: k8s.gcr.io/cluster-api/kubeadm-control-plane-controller:v1.1.5
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        resources: {}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: capi-kubeadm-control-plane-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capi-kubeadm-control-plane-webhook-service-cert
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata: # kpt-merge: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-control-plane-serving-cert
+  namespace: capi-kubeadm-control-plane-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'cert-manager.io|Certificate|capi-kubeadm-control-plane-system|capi-kubeadm-control-plane-serving-cert'
+spec:
+  dnsNames:
+  - capi-kubeadm-control-plane-webhook-service.capi-kubeadm-control-plane-system.svc
+  - capi-kubeadm-control-plane-webhook-service.capi-kubeadm-control-plane-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capi-kubeadm-control-plane-selfsigned-issuer
+  secretName: capi-kubeadm-control-plane-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata: # kpt-merge: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-selfsigned-issuer
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-control-plane-selfsigned-issuer
+  namespace: capi-kubeadm-control-plane-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'cert-manager.io|Issuer|capi-kubeadm-control-plane-system|capi-kubeadm-control-plane-selfsigned-issuer'
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata: # kpt-merge: /capi-kubeadm-control-plane-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+    internal.kpt.dev/upstream-identifier: 'admissionregistration.k8s.io|MutatingWebhookConfiguration|default|capi-kubeadm-control-plane-mutating-webhook-configuration'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-control-plane-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /mutate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+  failurePolicy: Fail
+  name: default.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanetemplates
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata: # kpt-merge: /capi-kubeadm-control-plane-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: capi-kubeadm-control-plane-system/capi-kubeadm-control-plane-serving-cert
+    internal.kpt.dev/upstream-identifier: 'admissionregistration.k8s.io|ValidatingWebhookConfiguration|default|capi-kubeadm-control-plane-validating-webhook-configuration'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: control-plane-kubeadm
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-kubeadm-control-plane-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanes
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /validate-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplanetemplate
+  failurePolicy: Fail
+  name: validation.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanetemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-kubeadm-control-plane-webhook-service
+      namespace: capi-kubeadm-control-plane-system
+      path: /validate-scale-controlplane-cluster-x-k8s-io-v1beta1-kubeadmcontrolplane
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation-scale.kubeadmcontrolplane.controlplane.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - controlplane.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - UPDATE
+    resources:
+    - kubeadmcontrolplanes/scale
+  sideEffects: None

--- a/nephio-r1-sandbox/cluster-capi/cluster-api-core.yaml
+++ b/nephio-r1-sandbox/cluster-capi/cluster-api-core.yaml
@@ -1,0 +1,7308 @@
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /capi-system
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  name: capi-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|capi-system'
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /clusterclasses.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|clusterclasses.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: clusterclasses.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterClass
+    listKind: ClusterClassList
+    plural: clusterclasses
+    shortNames:
+    - cc
+    singular: clusterclass
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterClass
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: ClusterClass is a template which can be used to create managed topologies.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterClassSpec describes the desired state of the ClusterClass.
+            properties:
+              controlPlane:
+                description: ControlPlane is a reference to a local struct that holds the details for provisioning the Control Plane for the Cluster.
+                properties:
+                  machineInfrastructure:
+                    description: "MachineTemplate defines the metadata and infrastructure information for control plane machines. \n This field is supported if and only if the control plane provider template referenced above is Machine based and supports setting replicas."
+                    properties:
+                      ref:
+                        description: Ref is a required reference to a custom resource offered by a provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                    required:
+                    - ref
+                    type: object
+                  metadata:
+                    description: "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the topology. \n This field is supported if and only if the control plane provider template referenced is Machine based."
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  ref:
+                    description: Ref is a required reference to a custom resource offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - ref
+                type: object
+              infrastructure:
+                description: Infrastructure is a reference to a provider-specific template that holds the details for provisioning infrastructure specific cluster for the underlying provider. The underlying provider is responsible for the implementation of the template to an infrastructure cluster.
+                properties:
+                  ref:
+                    description: Ref is a required reference to a custom resource offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - ref
+                type: object
+              workers:
+                description: Workers describes the worker nodes for the cluster. It is a collection of node types which can be used to create the worker nodes of the cluster.
+                properties:
+                  machineDeployments:
+                    description: MachineDeployments is a list of machine deployment classes that can be used to create a set of worker nodes.
+                    items:
+                      description: MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster provisioned using the `ClusterClass`.
+                      properties:
+                        class:
+                          description: Class denotes a type of worker node present in the cluster, this name MUST be unique within a ClusterClass and can be referenced in the Cluster to create a managed MachineDeployment.
+                          type: string
+                        template:
+                          description: Template is a local struct containing a collection of templates for creation of MachineDeployment objects representing a set of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: Bootstrap contains the bootstrap template reference to be used for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: Ref is a required reference to a custom resource offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: Infrastructure contains the infrastructure template reference to be used for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: Ref is a required reference to a custom resource offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterClass
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterClass is a template which can be used to create managed topologies.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterClassSpec describes the desired state of the ClusterClass.
+            properties:
+              controlPlane:
+                description: ControlPlane is a reference to a local struct that holds the details for provisioning the Control Plane for the Cluster.
+                properties:
+                  machineHealthCheck:
+                    description: MachineHealthCheck defines a MachineHealthCheck for this ControlPlaneClass. This field is supported if and only if the ControlPlane provider template referenced above is Machine based and supports setting replicas.
+                    properties:
+                      maxUnhealthy:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by "selector" are not healthy.
+                        x-kubernetes-int-or-string: true
+                      nodeStartupTimeout:
+                        description: Machines older than this duration without a node will be considered to have failed and will be remediated. If you wish to disable this feature, set the value explicitly to 0.
+                        type: string
+                      remediationTemplate:
+                        description: "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API."
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      unhealthyConditions:
+                        description: UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy. The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                        items:
+                          description: UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.
+                          properties:
+                            status:
+                              minLength: 1
+                              type: string
+                            timeout:
+                              type: string
+                            type:
+                              minLength: 1
+                              type: string
+                          required:
+                          - status
+                          - timeout
+                          - type
+                          type: object
+                        type: array
+                      unhealthyRange:
+                        description: 'Any further remediation is only allowed if the number of machines selected by "selector" as not healthy is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy. Eg. "[3-5]" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines'
+                        type: string
+                    type: object
+                  machineInfrastructure:
+                    description: "MachineInfrastructure defines the metadata and infrastructure information for control plane machines. \n This field is supported if and only if the control plane provider template referenced above is Machine based and supports setting replicas."
+                    properties:
+                      ref:
+                        description: Ref is a required reference to a custom resource offered by a provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                    required:
+                    - ref
+                    type: object
+                  metadata:
+                    description: "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the topology. \n This field is supported if and only if the control plane provider template referenced is Machine based."
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  ref:
+                    description: Ref is a required reference to a custom resource offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - ref
+                type: object
+              infrastructure:
+                description: Infrastructure is a reference to a provider-specific template that holds the details for provisioning infrastructure specific cluster for the underlying provider. The underlying provider is responsible for the implementation of the template to an infrastructure cluster.
+                properties:
+                  ref:
+                    description: Ref is a required reference to a custom resource offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                required:
+                - ref
+                type: object
+              patches:
+                description: 'Patches defines the patches which are applied to customize referenced templates of a ClusterClass. Note: Patches will be applied in the order of the array.'
+                items:
+                  description: ClusterClassPatch defines a patch which is applied to customize the referenced templates.
+                  properties:
+                    definitions:
+                      description: 'Definitions define the patches inline. Note: Patches will be applied in the order of the array.'
+                      items:
+                        description: PatchDefinition defines a patch which is applied to customize the referenced templates.
+                        properties:
+                          jsonPatches:
+                            description: 'JSONPatches defines the patches which should be applied on the templates matching the selector. Note: Patches will be applied in the order of the array.'
+                            items:
+                              description: JSONPatch defines a JSON patch.
+                              properties:
+                                op:
+                                  description: 'Op defines the operation of the patch. Note: Only `add`, `replace` and `remove` are supported.'
+                                  type: string
+                                path:
+                                  description: 'Path defines the path of the patch. Note: Only the spec of a template can be patched, thus the path has to start with /spec/. Note: For now the only allowed array modifications are `append` and `prepend`, i.e.: * for op: `add`: only index 0 (prepend) and - (append) are allowed * for op: `replace` or `remove`: no indexes are allowed'
+                                  type: string
+                                value:
+                                  description: 'Value defines the value of the patch. Note: Either Value or ValueFrom is required for add and replace operations. Only one of them is allowed to be set at the same time. Note: We have to use apiextensionsv1.JSON instead of our JSON type, because controller-tools has a hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type (unset type field). Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111'
+                                  x-kubernetes-preserve-unknown-fields: true
+                                valueFrom:
+                                  description: 'ValueFrom defines the value of the patch. Note: Either Value or ValueFrom is required for add and replace operations. Only one of them is allowed to be set at the same time.'
+                                  properties:
+                                    template:
+                                      description: 'Template is the Go template to be used to calculate the value. A template can reference variables defined in .spec.variables and builtin variables. Note: The template must evaluate to a valid YAML or JSON value.'
+                                      type: string
+                                    variable:
+                                      description: Variable is the variable to be used as value. Variable can be one of the variables defined in .spec.variables or a builtin variable.
+                                      type: string
+                                  type: object
+                              required:
+                              - op
+                              - path
+                              type: object
+                            type: array
+                          selector:
+                            description: Selector defines on which templates the patch should be applied.
+                            properties:
+                              apiVersion:
+                                description: APIVersion filters templates by apiVersion.
+                                type: string
+                              kind:
+                                description: Kind filters templates by kind.
+                                type: string
+                              matchResources:
+                                description: MatchResources selects templates based on where they are referenced.
+                                properties:
+                                  controlPlane:
+                                    description: 'ControlPlane selects templates referenced in .spec.ControlPlane. Note: this will match the controlPlane and also the controlPlane machineInfrastructure (depending on the kind and apiVersion).'
+                                    type: boolean
+                                  infrastructureCluster:
+                                    description: InfrastructureCluster selects templates referenced in .spec.infrastructure.
+                                    type: boolean
+                                  machineDeploymentClass:
+                                    description: MachineDeploymentClass selects templates referenced in specific MachineDeploymentClasses in .spec.workers.machineDeployments.
+                                    properties:
+                                      names:
+                                        description: Names selects templates by class names.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                type: object
+                            required:
+                            - apiVersion
+                            - kind
+                            - matchResources
+                            type: object
+                        required:
+                        - jsonPatches
+                        - selector
+                        type: object
+                      type: array
+                    description:
+                      description: Description is a human-readable description of this patch.
+                      type: string
+                    enabledIf:
+                      description: EnabledIf is a Go template to be used to calculate if a patch should be enabled. It can reference variables defined in .spec.variables and builtin variables. The patch will be enabled if the template evaluates to `true`, otherwise it will be disabled. If EnabledIf is not set, the patch will be enabled per default.
+                      type: string
+                    name:
+                      description: Name of the patch.
+                      type: string
+                  required:
+                  - definitions
+                  - name
+                  type: object
+                type: array
+              variables:
+                description: Variables defines the variables which can be configured in the Cluster topology and are then used in patches.
+                items:
+                  description: ClusterClassVariable defines a variable which can be configured in the Cluster topology and used in patches.
+                  properties:
+                    name:
+                      description: Name of the variable.
+                      type: string
+                    required:
+                      description: 'Required specifies if the variable is required. Note: this applies to the variable as a whole and thus the top-level object defined in the schema. If nested fields are required, this will be specified inside the schema.'
+                      type: boolean
+                    schema:
+                      description: Schema defines the schema of the variable.
+                      properties:
+                        openAPIV3Schema:
+                          description: OpenAPIV3Schema defines the schema of a variable via OpenAPI v3 schema. The schema is a subset of the schema used in Kubernetes CRDs.
+                          properties:
+                            default:
+                              description: 'Default is the default value of the variable. NOTE: Can be set for all types.'
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: Description is a human-readable description of this variable.
+                              type: string
+                            enum:
+                              description: 'Enum is the list of valid values of the variable. NOTE: Can be set for all types.'
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            example:
+                              description: Example is an example for this variable.
+                              x-kubernetes-preserve-unknown-fields: true
+                            exclusiveMaximum:
+                              description: 'ExclusiveMaximum specifies if the Maximum is exclusive. NOTE: Can only be set if type is integer or number.'
+                              type: boolean
+                            exclusiveMinimum:
+                              description: 'ExclusiveMinimum specifies if the Minimum is exclusive. NOTE: Can only be set if type is integer or number.'
+                              type: boolean
+                            format:
+                              description: 'Format is an OpenAPI v3 format string. Unknown formats are ignored. For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we''re currently using) https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go NOTE: Can only be set if type is string.'
+                              type: string
+                            items:
+                              description: 'Items specifies fields of an array. NOTE: Can only be set if type is array. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.'
+                              x-kubernetes-preserve-unknown-fields: true
+                            maxItems:
+                              description: 'MaxItems is the max length of an array variable. NOTE: Can only be set if type is array.'
+                              format: int64
+                              type: integer
+                            maxLength:
+                              description: 'MaxLength is the max length of a string variable. NOTE: Can only be set if type is string.'
+                              format: int64
+                              type: integer
+                            maximum:
+                              description: 'Maximum is the maximum of an integer or number variable. If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum. If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum. NOTE: Can only be set if type is integer or number.'
+                              format: int64
+                              type: integer
+                            minItems:
+                              description: 'MinItems is the min length of an array variable. NOTE: Can only be set if type is array.'
+                              format: int64
+                              type: integer
+                            minLength:
+                              description: 'MinLength is the min length of a string variable. NOTE: Can only be set if type is string.'
+                              format: int64
+                              type: integer
+                            minimum:
+                              description: 'Minimum is the minimum of an integer or number variable. If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum. If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum. NOTE: Can only be set if type is integer or number.'
+                              format: int64
+                              type: integer
+                            pattern:
+                              description: 'Pattern is the regex which a string variable must match. NOTE: Can only be set if type is string.'
+                              type: string
+                            properties:
+                              description: 'Properties specifies fields of an object. NOTE: Can only be set if type is object. NOTE: This field uses PreserveUnknownFields and Schemaless, because recursive validation is not possible.'
+                              x-kubernetes-preserve-unknown-fields: true
+                            required:
+                              description: 'Required specifies which fields of an object are required. NOTE: Can only be set if type is object.'
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              description: 'Type is the type of the variable. Valid values are: object, array, string, integer, number or boolean.'
+                              type: string
+                            uniqueItems:
+                              description: 'UniqueItems specifies if items in an array must be unique. NOTE: Can only be set if type is array.'
+                              type: boolean
+                          required:
+                          - type
+                          type: object
+                      required:
+                      - openAPIV3Schema
+                      type: object
+                  required:
+                  - name
+                  - required
+                  - schema
+                  type: object
+                type: array
+              workers:
+                description: Workers describes the worker nodes for the cluster. It is a collection of node types which can be used to create the worker nodes of the cluster.
+                properties:
+                  machineDeployments:
+                    description: MachineDeployments is a list of machine deployment classes that can be used to create a set of worker nodes.
+                    items:
+                      description: MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster provisioned using the `ClusterClass`.
+                      properties:
+                        class:
+                          description: Class denotes a type of worker node present in the cluster, this name MUST be unique within a ClusterClass and can be referenced in the Cluster to create a managed MachineDeployment.
+                          type: string
+                        machineHealthCheck:
+                          description: MachineHealthCheck defines a MachineHealthCheck for this MachineDeploymentClass.
+                          properties:
+                            maxUnhealthy:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by "selector" are not healthy.
+                              x-kubernetes-int-or-string: true
+                            nodeStartupTimeout:
+                              description: Machines older than this duration without a node will be considered to have failed and will be remediated. If you wish to disable this feature, set the value explicitly to 0.
+                              type: string
+                            remediationTemplate:
+                              description: "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API."
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                  type: string
+                                kind:
+                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                                namespace:
+                                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                  type: string
+                                resourceVersion:
+                                  description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                  type: string
+                                uid:
+                                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                  type: string
+                              type: object
+                            unhealthyConditions:
+                              description: UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy. The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                              items:
+                                description: UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.
+                                properties:
+                                  status:
+                                    minLength: 1
+                                    type: string
+                                  timeout:
+                                    type: string
+                                  type:
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - status
+                                - timeout
+                                - type
+                                type: object
+                              type: array
+                            unhealthyRange:
+                              description: 'Any further remediation is only allowed if the number of machines selected by "selector" as not healthy is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy. Eg. "[3-5]" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines'
+                              type: string
+                          type: object
+                        template:
+                          description: Template is a local struct containing a collection of templates for creation of MachineDeployment objects representing a set of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: Bootstrap contains the bootstrap template reference to be used for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: Ref is a required reference to a custom resource offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: Infrastructure contains the infrastructure template reference to be used for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: Ref is a required reference to a custom resource offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                      type: string
+                                    kind:
+                                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    namespace:
+                                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                      type: string
+                                    resourceVersion:
+                                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    uid:
+                                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                      type: string
+                                  type: object
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    type: array
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /clusterresourcesetbindings.addons.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|clusterresourcesetbindings.addons.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: clusterresourcesetbindings.addons.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSetBinding
+    listKind: ClusterResourceSetBindingList
+    plural: clusterresourcesetbindings
+    singular: clusterresourcesetbinding
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: Bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: Resources is a list of resources that the ClusterResourceSet has.
+                      items:
+                        description: ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: Applied is to track if a resource is applied to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'Kind of the resource. Supported kinds are: Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: LastAppliedTime identifies when this resource was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: Name of the resource that is in the same namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSetBinding
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: Bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: Resources is a list of resources that the ClusterResourceSet has.
+                      items:
+                        description: ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: Applied is to track if a resource is applied to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'Kind of the resource. Supported kinds are: Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: LastAppliedTime identifies when this resource was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: Name of the resource that is in the same namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSetBinding
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetBindingSpec defines the desired state of ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: Bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: ClusterResourceSetName is the name of the ClusterResourceSet that is applied to the owner cluster of the binding.
+                      type: string
+                    resources:
+                      description: Resources is a list of resources that the ClusterResourceSet has.
+                      items:
+                        description: ResourceBinding shows the status of a resource that belongs to a ClusterResourceSet matched by the owner cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: Applied is to track if a resource is applied to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: Hash is the hash of a resource's data. This can be used to decide if a resource is changed. For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            type: string
+                          kind:
+                            description: 'Kind of the resource. Supported kinds are: Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: LastAppliedTime identifies when this resource was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: Name of the resource that is in the same namespace with ClusterResourceSet object.
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /clusterresourcesets.addons.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|clusterresourcesets.addons.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: clusterresourcesets.addons.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSet
+    listKind: ClusterResourceSetList
+    plural: clusterresourcesets
+    singular: clusterresourceset
+  scope: Namespaced
+  versions:
+  - name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSet is the Schema for the clusterresourcesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              resources:
+                description: Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'Kind of the resource. Supported kinds are: Secrets and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: Name of the resource that is in the same namespace with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: Conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSet is the Schema for the clusterresourcesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable. Label selector cannot be empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              resources:
+                description: Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'Kind of the resource. Supported kinds are: Secrets and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: Name of the resource that is in the same namespace with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: Conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSet is the Schema for the clusterresourcesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterResourceSetSpec defines the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: Label selector for Clusters. The Clusters that are selected by this will be the ones affected by this ClusterResourceSet. It must match the Cluster labels. This field is immutable. Label selector cannot be empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              resources:
+                description: Resources is a list of Secrets/ConfigMaps where each contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'Kind of the resource. Supported kinds are: Secrets and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: Name of the resource that is in the same namespace with ClusterResourceSet object.
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+              strategy:
+                description: Strategy is the strategy to be used during applying resources. Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: ClusterResourceSetStatus defines the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: Conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /clusters.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|clusters.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: clusters.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    shortNames:
+    - cl
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: APIServerPort specifies the port the API Server should bind to. Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              infrastructureRef:
+                description: InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              paused:
+                description: Paused can be used to prevent controllers from processing the Cluster and all its associated objects.
+                type: boolean
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneInitialized:
+                description: ControlPlaneInitialized defines if the control plane has been initialized.
+                type: boolean
+              controlPlaneReady:
+                description: ControlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of failure domain objects synced from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: APIServerPort specifies the port the API Server should bind to. Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              infrastructureRef:
+                description: InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              paused:
+                description: Paused can be used to prevent controllers from processing the Cluster and all its associated objects.
+                type: boolean
+              topology:
+                description: 'This encapsulates the topology for the cluster. NOTE: It is required to enable the ClusterTopology feature gate flag to activate managed topologies support; this feature is highly experimental, and parts of it might still be not implemented.'
+                properties:
+                  class:
+                    description: The name of the ClusterClass object to create the topology.
+                    type: string
+                  controlPlane:
+                    description: ControlPlane describes the cluster control plane.
+                    properties:
+                      metadata:
+                        description: "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass. \n This field is supported if and only if the control plane provider template referenced in the ClusterClass is Machine based."
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                            type: object
+                        type: object
+                      replicas:
+                        description: Replicas is the number of control plane nodes. If the value is nil, the ControlPlane object is created without the number of Replicas and it's assumed that the control plane controller does not implement support for this field. When specified against a control plane provider that lacks support for this field, this value will be ignored.
+                        format: int32
+                        type: integer
+                    type: object
+                  rolloutAfter:
+                    description: RolloutAfter performs a rollout of the entire cluster one component at a time, control plane first and then machine deployments.
+                    format: date-time
+                    type: string
+                  version:
+                    description: The Kubernetes version of the cluster.
+                    type: string
+                  workers:
+                    description: Workers encapsulates the different constructs that form the worker nodes for the cluster.
+                    properties:
+                      machineDeployments:
+                        description: MachineDeployments is a list of machine deployments in the cluster.
+                        items:
+                          description: MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology. This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: Class is the name of the MachineDeploymentClass used to create the set of worker nodes. This should match one of the deployment classes defined in the ClusterClass object mentioned in the `Cluster.Spec.Class` field.
+                              type: string
+                            metadata:
+                              description: Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                            name:
+                              description: Name is the unique identifier for this MachineDeploymentTopology. The value is used with other unique identifiers to create a MachineDeployment's Name (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length, the values are hashed together.
+                              type: string
+                            replicas:
+                              description: Replicas is the number of worker nodes belonging to this set. If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero) and it's assumed that an external entity (like cluster autoscaler) is responsible for the management of this value.
+                              format: int32
+                              type: integer
+                          required:
+                          - class
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - class
+                - version
+                type: object
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneReady:
+                description: ControlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of failure domain objects synced from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Cluster
+      jsonPath: .spec.topology.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSpec defines the desired state of Cluster.
+            properties:
+              clusterNetwork:
+                description: Cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: APIServerPort specifies the port the API Server should bind to. Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: The network ranges from which Pod networks are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: Domain name for services.
+                    type: string
+                  services:
+                    description: The network ranges from which service VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: ControlPlaneRef is an optional reference to a provider-specific resource that holds the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              infrastructureRef:
+                description: InfrastructureRef is a reference to a provider-specific resource that holds the details for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              paused:
+                description: Paused can be used to prevent controllers from processing the Cluster and all its associated objects.
+                type: boolean
+              topology:
+                description: 'This encapsulates the topology for the cluster. NOTE: It is required to enable the ClusterTopology feature gate flag to activate managed topologies support; this feature is highly experimental, and parts of it might still be not implemented.'
+                properties:
+                  class:
+                    description: The name of the ClusterClass object to create the topology.
+                    type: string
+                  controlPlane:
+                    description: ControlPlane describes the cluster control plane.
+                    properties:
+                      metadata:
+                        description: "Metadata is the metadata applied to the machines of the ControlPlane. At runtime this metadata is merged with the corresponding metadata from the ClusterClass. \n This field is supported if and only if the control plane provider template referenced in the ClusterClass is Machine based."
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                            type: object
+                        type: object
+                      replicas:
+                        description: Replicas is the number of control plane nodes. If the value is nil, the ControlPlane object is created without the number of Replicas and it's assumed that the control plane controller does not implement support for this field. When specified against a control plane provider that lacks support for this field, this value will be ignored.
+                        format: int32
+                        type: integer
+                    type: object
+                  rolloutAfter:
+                    description: RolloutAfter performs a rollout of the entire cluster one component at a time, control plane first and then machine deployments.
+                    format: date-time
+                    type: string
+                  variables:
+                    description: Variables can be used to customize the Cluster through patches. They must comply to the corresponding VariableClasses defined in the ClusterClass.
+                    items:
+                      description: ClusterVariable can be used to customize the Cluster through patches. It must comply to the corresponding ClusterClassVariable defined in the ClusterClass.
+                      properties:
+                        name:
+                          description: Name of the variable.
+                          type: string
+                        value:
+                          description: 'Value of the variable. Note: the value will be validated against the schema of the corresponding ClusterClassVariable from the ClusterClass. Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools, i.e. it is not possible to have no type field. Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111'
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  version:
+                    description: The Kubernetes version of the cluster.
+                    type: string
+                  workers:
+                    description: Workers encapsulates the different constructs that form the worker nodes for the cluster.
+                    properties:
+                      machineDeployments:
+                        description: MachineDeployments is a list of machine deployments in the cluster.
+                        items:
+                          description: MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology. This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: Class is the name of the MachineDeploymentClass used to create the set of worker nodes. This should match one of the deployment classes defined in the ClusterClass object mentioned in the `Cluster.Spec.Class` field.
+                              type: string
+                            failureDomain:
+                              description: FailureDomain is the failure domain the machines will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                              type: string
+                            metadata:
+                              description: Metadata is the metadata applied to the machines of the MachineDeployment. At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                  type: object
+                              type: object
+                            name:
+                              description: Name is the unique identifier for this MachineDeploymentTopology. The value is used with other unique identifiers to create a MachineDeployment's Name (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length, the values are hashed together.
+                              type: string
+                            replicas:
+                              description: Replicas is the number of worker nodes belonging to this set. If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to zero) and it's assumed that an external entity (like cluster autoscaler) is responsible for the management of this value.
+                              format: int32
+                              type: integer
+                            variables:
+                              description: Variables can be used to customize the MachineDeployment through patches.
+                              properties:
+                                overrides:
+                                  description: Overrides can be used to override Cluster level variables.
+                                  items:
+                                    description: ClusterVariable can be used to customize the Cluster through patches. It must comply to the corresponding ClusterClassVariable defined in the ClusterClass.
+                                    properties:
+                                      name:
+                                        description: Name of the variable.
+                                        type: string
+                                      value:
+                                        description: 'Value of the variable. Note: the value will be validated against the schema of the corresponding ClusterClassVariable from the ClusterClass. Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools, i.e. it is not possible to have no type field. Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111'
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                              type: object
+                          required:
+                          - class
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                required:
+                - class
+                - version
+                type: object
+            type: object
+          status:
+            description: ClusterStatus defines the observed state of Cluster.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneReady:
+                description: ControlPlaneReady defines if the control plane is ready.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: FailureDomainSpec is the Schema for Cluster API failure domains. It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a slice of failure domain objects synced from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: FailureMessage indicates that there is a fatal problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a fatal problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /machinedeployments.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|machinedeployments.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machinedeployments.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineDeployment
+    listKind: MachineDeploymentList
+    plural: machinedeployments
+    shortNames:
+    - md
+    singular: machinedeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for machines. Existing MachineSets whose machines are selected by this will be the ones affected by this deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              strategy:
+                description: The deployment strategy to use to replace existing machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. \n Deprecated: This field has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          data:
+                            description: "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this deployment. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet available or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for machines. Existing MachineSets whose machines are selected by this will be the ones affected by this deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              strategy:
+                description: The deployment strategy to use to replace existing machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: DeletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling. Valid values are "Random, "Newest", "Oldest" When no value is supplied, the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this deployment. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet available or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineDeployment
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineDeploymentSpec defines the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Note that progress will not be estimated during the time a deployment is paused. Defaults to 600s.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: Label selector for machines. Existing MachineSets whose machines are selected by this will be the ones affected by this deployment. It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              strategy:
+                description: The deployment strategy to use to replace existing machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: DeletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling. Valid values are "Random, "Newest", "Oldest" When no value is supplied, the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: MachineDeploymentStatus defines the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least minReadySeconds) targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of a MachineDeployment (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                type: string
+              readyReplicas:
+                description: Total number of ready machines targeted by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this deployment (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this deployment. This is the total number of machines that are still required for the deployment to have 100% available capacity. They may either be machines that are running but not yet available or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this deployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /machinehealthchecks.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|machinehealthchecks.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machinehealthchecks.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineHealthCheck
+    listKind: MachineHealthCheckList
+    plural: machinehealthchecks
+    shortNames:
+    - mhc
+    - mhcs
+    singular: machinehealthcheck
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: Machines older than this duration without a node will be considered to have failed and will be remediated.
+                type: string
+              remediationTemplate:
+                description: "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API."
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              selector:
+                description: Label selector to match machines whose health will be exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              unhealthyConditions:
+                description: UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: Conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: Targets shows the current list of machines the machine health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineHealthCheck
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: Machines older than this duration without a node will be considered to have failed and will be remediated. If not set, this value is defaulted to 10 minutes. If you wish to disable this feature, set the value explicitly to 0.
+                type: string
+              remediationTemplate:
+                description: "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API."
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              selector:
+                description: Label selector to match machines whose health will be exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              unhealthyConditions:
+                description: UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+              unhealthyRange:
+                description: 'Any further remediation is only allowed if the number of machines selected by "selector" as not healthy is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy. Eg. "[3-5]" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines'
+                pattern: ^\[[0-9]+-[0-9]+\]$
+                type: string
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: Conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: Targets shows the current list of machines the machine health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    - description: Time duration since creation of MachineHealthCheck
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of machine health check policy
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Any further remediation is only allowed if at most "MaxUnhealthy" machines selected by "selector" are not healthy.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: Machines older than this duration without a node will be considered to have failed and will be remediated. If not set, this value is defaulted to 10 minutes. If you wish to disable this feature, set the value explicitly to 0.
+                type: string
+              remediationTemplate:
+                description: "RemediationTemplate is a reference to a remediation template provided by an infrastructure provider. \n This field is completely optional, when filled, the MachineHealthCheck controller creates a new object from the template referenced and hands off remediation of the machine to a controller that lives outside of Cluster API."
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              selector:
+                description: Label selector to match machines whose health will be exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              unhealthyConditions:
+                description: UnhealthyConditions contains a list of the conditions that determine whether a node is considered unhealthy.  The conditions are combined in a logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: UnhealthyCondition represents a Node condition type and value with a timeout specified as a duration.  When the named condition has been in the given status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      minLength: 1
+                      type: string
+                    timeout:
+                      type: string
+                    type:
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                minItems: 1
+                type: array
+              unhealthyRange:
+                description: 'Any further remediation is only allowed if the number of machines selected by "selector" as not healthy is within the range of "UnhealthyRange". Takes precedence over MaxUnhealthy. Eg. "[3-5]" - This means that remediation will be allowed only when: (a) there are at least 3 unhealthy machines (and) (b) there are at most 5 unhealthy machines'
+                pattern: ^\[[0-9]+-[0-9]+\]$
+                type: string
+            required:
+            - clusterName
+            - selector
+            - unhealthyConditions
+            type: object
+          status:
+            description: Most recently observed status of MachineHealthCheck resource
+            properties:
+              conditions:
+                description: Conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: total number of healthy machines counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: total number of machines counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: RemediationsAllowed is the number of further remediations allowed by this machine health check before maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: Targets shows the current list of machines the machine health check is watching
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /machinepools.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|machinepools.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machinepools.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachinePool
+    listKind: MachinePoolList
+    plural: machinepools
+    shortNames:
+    - mp
+    singular: machinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine instances should be ready. Defaults to 0 (machine instance will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              strategy:
+                description: The deployment strategy to use to replace existing machine instances with new ones.
+                properties:
+                  rollingUpdate:
+                    description: Rolling update config params. Present only if MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled above the desired number of machines. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 1. Example: when this is set to 30%, the new MachineSet can be scaled up immediately when the rolling update starts, such that the total number of old and new machines do not exceed 130% of desired machines. Once old machines have been killed, new MachineSet can be scaled up further, ensuring that total number of machines running at any time during the update is at most 130% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 0. Example: when this is set to 30%, the old MachineSet can be scaled down to 70% of desired machines immediately when the rolling update starts. Once new machines are ready, old MachineSet can be scaled down further, followed by scaling up the new MachineSet, ensuring that the total number of machines available at all times during the update is at least 70% of desired machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Currently the only supported strategy is "RollingUpdate". Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. \n Deprecated: This field has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          data:
+                            description: "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it they exist.
+                items:
+                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage. 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted". Those cannot be well described when embedded. 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen. 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple and the version of the actual struct is irrelevant. 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted by this machine pool. This is the total number of machine instances that are still required for the machine pool to have 100% available capacity. They may either be machine instances that are running but not yet available or machine instances that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine instances should be ready. Defaults to 0 (machine instance will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it they exist.
+                items:
+                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage. 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted". Those cannot be well described when embedded. 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen. 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple and the version of the actual struct is irrelevant. 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted by this machine pool. This is the total number of machine instances that are still required for the machine pool to have 100% available capacity. They may either be machine instances that are running but not yet available or machine instances that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachinePoolSpec defines the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              failureDomains:
+                description: FailureDomains is the list of failure domains this MachinePool should be attached to.
+                items:
+                  type: string
+                type: array
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine instances should be ready. Defaults to 0 (machine instance will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: ProviderIDList are the identification IDs of machine instances provided by the provider. This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  type: string
+                type: array
+              replicas:
+                description: Number of desired machines. Defaults to 1. This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: MachinePoolStatus defines the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage indicates that there is a problem reconciling the state, and will be set to a descriptive error message.
+                type: string
+              failureReason:
+                description: FailureReason indicates that there is a problem reconciling the state, and will be set to a token value suitable for programmatic interpretation.
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              nodeRefs:
+                description: NodeRefs will point to the corresponding Nodes if it they exist.
+                items:
+                  description: 'ObjectReference contains enough information to let you inspect or modify the referred object. --- New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs. 1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage. 2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted". Those cannot be well described when embedded. 3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen. 4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple and the version of the actual struct is irrelevant. 5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type will affect numerous schemas.  Don''t make new APIs embed an underspecified API type they do not control. Instead of using this type, create a locally provided and used type that is well-focused on your reference. For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .'
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of cluster actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              readyReplicas:
+                description: The number of ready replicas for this MachinePool. A machine is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machine instances targeted by this machine pool. This is the total number of machine instances that are still required for the machine pool to have 100% available capacity. They may either be machine instances that are running but not yet available or machine instances that still have not been created.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /machines.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|machines.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machines.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Machine
+    listKind: MachineList
+    plural: machines
+    shortNames:
+    - ma
+    singular: machine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      priority: 1
+      type: string
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  data:
+                    description: "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName."
+                    type: string
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                type: string
+              infrastructureRef:
+                description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                type: string
+              providerID:
+                description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: Addresses is a list of addresses assigned to the machine. This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              lastUpdated:
+                description: LastUpdated identifies when the phase of the Machine last transitioned.
+                format: date-time
+                type: string
+              nodeRef:
+                description: NodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              version:
+                description: Version specifies the current version of Kubernetes running on the corresponding Node. This is meant to be a means of bubbling up status from the Node to the Machine. It is entirely optional, but useful for end-user UX if it’s present.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      priority: 1
+      type: string
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                type: string
+              infrastructureRef:
+                description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                type: string
+              providerID:
+                description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: Addresses is a list of addresses assigned to the machine. This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              lastUpdated:
+                description: LastUpdated identifies when the phase of the Machine last transitioned.
+                format: date-time
+                type: string
+              nodeInfo:
+                description: 'NodeInfo is a set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info'
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: KubeProxy Version reported by the node.
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: 'MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html'
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: NodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+              version:
+                description: Version specifies the current version of Kubernetes running on the corresponding Node. This is meant to be a means of bubbling up status from the Node to the Machine. It is entirely optional, but useful for end-user UX if it’s present.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSpec defines the desired state of Machine.
+            properties:
+              bootstrap:
+                description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                        type: string
+                      kind:
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      namespace:
+                        description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                        type: string
+                      resourceVersion:
+                        description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                        type: string
+                      uid:
+                        description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                        type: string
+                    type: object
+                  dataSecretName:
+                    description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                    type: string
+                type: object
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              failureDomain:
+                description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                type: string
+              infrastructureRef:
+                description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              nodeDrainTimeout:
+                description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                type: string
+              providerID:
+                description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                type: string
+              version:
+                description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: MachineStatus defines the observed state of Machine.
+            properties:
+              addresses:
+                description: Addresses is a list of addresses assigned to the machine. This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: BootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: Conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: "FailureMessage will be set in the event that there is a terminal problem reconciling the Machine and will contain a more verbose string suitable for logging and human consumption. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              failureReason:
+                description: "FailureReason will be set in the event that there is a terminal problem reconciling the Machine and will contain a succinct value suitable for machine interpretation. \n This field should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the Machine's spec or the configuration of the controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the controller, or the responsible controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output."
+                type: string
+              infrastructureReady:
+                description: InfrastructureReady is the state of the infrastructure provider.
+                type: boolean
+              lastUpdated:
+                description: LastUpdated identifies when the phase of the Machine last transitioned.
+                format: date-time
+                type: string
+              nodeInfo:
+                description: 'NodeInfo is a set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info'
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: KubeProxy Version reported by the node.
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: 'MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html'
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: NodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the latest generation observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current phase of machine actuation. E.g. Pending, Running, Terminating, Failed etc.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /machinesets.cluster.x-k8s.io
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    controller-gen.kubebuilder.io/version: v0.8.0
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|machinesets.cluster.x-k8s.io'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: machinesets.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capi-webhook-service
+          namespace: capi-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+      - v1beta1
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineSet
+    listKind: MachineSetList
+    plural: machinesets
+    shortNames:
+    - ms
+    singular: machineset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              template:
+                description: Template is the object that describes the machine that will be created if insufficient replicas are detected. Object references to custom resources resources are treated as templates.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      generateName:
+                        description: "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server. \n If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header). \n Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                      name:
+                        description: "Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      namespace:
+                        description: "Namespace defines the space within each name must be unique. An empty namespace is equivalent to the \"default\" namespace, but \"default\" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty. \n Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces \n Deprecated: This field has no function and is going to be removed in a next release."
+                        type: string
+                      ownerReferences:
+                        description: "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller. \n Deprecated: This field has no function and is going to be removed in a next release."
+                        items:
+                          description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing controller.
+                              type: boolean
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                        type: array
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.Data without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          data:
+                            description: "Data contains the bootstrap data, such as cloud-init details scripts. If nil, the Machine should remain in the Pending state. \n Deprecated: Switch to DataSecretName."
+                            type: string
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              failureMessage:
+                type: string
+              failureReason:
+                description: "In the event that there is a terminal problem reconciling the replicas, both FailureReason and FailureMessage will be set. FailureReason will be populated with a succinct value suitable for machine interpretation, while FailureMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output."
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Time duration since creation of MachineSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              template:
+                description: Template is the object that describes the machine that will be created if insufficient replicas are detected. Object references to custom resources resources are treated as templates.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                type: string
+              failureReason:
+                description: "In the event that there is a terminal problem reconciling the replicas, both FailureReason and FailureMessage will be set. FailureReason will be populated with a succinct value suitable for machine interpretation, while FailureMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output."
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Time duration since creation of MachineSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineSet
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec defines the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: ClusterName is the name of the Cluster this object belongs to.
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              minReadySeconds:
+                description: MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready. Defaults to 0 (machine will be considered available as soon as it is ready)
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is a label query over machines that should match the replica count. Label keys and values that must match in order to be controlled by this MachineSet. It must match the machine template''s labels. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              template:
+                description: Template is the object that describes the machine that will be created if insufficient replicas are detected. Object references to custom resources resources are treated as templates.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                        type: object
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      bootstrap:
+                        description: Bootstrap is a reference to a local struct which encapsulates fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: ConfigRef is a reference to a bootstrap provider-specific resource that holds configuration details. The reference is optional to allow users/operators to specify Bootstrap.DataSecretName without the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                type: string
+                              kind:
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              namespace:
+                                description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                type: string
+                              resourceVersion:
+                                description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                type: string
+                              uid:
+                                description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                type: string
+                            type: object
+                          dataSecretName:
+                            description: DataSecretName is the name of the secret that stores the bootstrap data script. If nil, the Machine should remain in the Pending state.
+                            type: string
+                        type: object
+                      clusterName:
+                        description: ClusterName is the name of the Cluster this object belongs to.
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: FailureDomain is the failure domain the machine will be created in. Must match a key in the FailureDomains map stored on the cluster object.
+                        type: string
+                      infrastructureRef:
+                        description: InfrastructureRef is a required reference to a custom resource offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                            type: string
+                          kind:
+                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          namespace:
+                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                            type: string
+                          resourceVersion:
+                            description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                            type: string
+                          uid:
+                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                            type: string
+                        type: object
+                      nodeDrainTimeout:
+                        description: 'NodeDrainTimeout is the total amount of time that the controller will spend on draining a node. The default value is 0, meaning that the node can be drained without any time limitations. NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`'
+                        type: string
+                      providerID:
+                        description: ProviderID is the identification ID of the machine provided by the provider. This field must match the provider ID as seen on the node object corresponding to this machine. This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a generic out-of-tree provider for autoscaler, this field is required by autoscaler to be able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver and then a comparison is done to find out unregistered machines and are marked for delete. This field will be set by the actuators and consumed by higher level entities like autoscaler that will be interfacing with cluster-api as generic provider.
+                        type: string
+                      version:
+                        description: Version defines the desired Kubernetes version. This field is meant to be optionally used by bootstrap providers.
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: MachineSetStatus defines the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions defines current service state of the MachineSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about the transition. This field may be empty.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                      type: string
+                    severity:
+                      description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                type: string
+              failureReason:
+                description: "In the event that there is a terminal problem reconciling the replicas, both FailureReason and FailureMessage will be set. FailureReason will be populated with a succinct value suitable for machine interpretation, while FailureMessage will contain a more verbose string suitable for logging and human consumption. \n These fields should not be set for transitive errors that a controller faces that are expected to be fixed automatically over time (like service outages), but instead indicate that something is fundamentally wrong with the MachineTemplate's spec or the configuration of the machine controller, and that manual intervention is required. Examples of terminal errors would be invalid combinations of settings in the spec, values that are unsupported by the machine controller, or the responsible machine controller itself being critically misconfigured. \n Any transient errors that occur during the reconciliation of Machines can be added as events to the MachineSet object and/or logged in the controller's output."
+                type: string
+              fullyLabeledReplicas:
+                description: The number of replicas that have labels matching the labels of the machine template of the MachineSet.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: 'Selector is the same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors'
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: # kpt-merge: capi-system/capi-manager
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-manager
+  namespace: capi-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|capi-system|capi-manager'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: # kpt-merge: capi-system/capi-leader-election-role
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-leader-election-role
+  namespace: capi-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|capi-system|capi-leader-election-role'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      cluster.x-k8s.io/aggregate-to-manager: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /capi-aggregated-manager-role
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-aggregated-manager-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|capi-aggregated-manager-role'
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /capi-manager-role
+  labels:
+    cluster.x-k8s.io/aggregate-to-manager: "true"
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-manager-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|capi-manager-role'
+rules:
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - addons.cluster.x-k8s.io
+  resources:
+  - clusterresourcesets/finalizers
+  - clusterresourcesets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusterclasses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/finalizers
+  - clusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/finalizers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinedeployments
+  - machinedeployments/finalizers
+  - machinedeployments/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinehealthchecks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinehealthchecks
+  - machinehealthchecks/finalizers
+  - machinehealthchecks/status
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/finalizers
+  - machinepools/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/finalizers
+  - machines/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  - machinesets/finalizers
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machinesets
+  - machinesets/finalizers
+  - machinesets/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: capi-system/capi-leader-election-rolebinding
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-leader-election-rolebinding
+  namespace: capi-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|capi-system|capi-leader-election-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: capi-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /capi-manager-rolebinding
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-manager-rolebinding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|capi-manager-rolebinding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capi-aggregated-manager-role
+subjects:
+- kind: ServiceAccount
+  name: capi-manager
+  namespace: capi-system
+---
+apiVersion: v1
+kind: Service
+metadata: # kpt-merge: capi-system/capi-webhook-service
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-webhook-service
+  namespace: capi-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|capi-system|capi-webhook-service'
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    cluster.x-k8s.io/provider: cluster-api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: capi-system/capi-controller-manager
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+    control-plane: controller-manager
+  name: capi-controller-manager
+  namespace: capi-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|capi-system|capi-controller-manager'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/provider: cluster-api
+      control-plane: controller-manager
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        cluster.x-k8s.io/provider: cluster-api
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --metrics-bind-addr=localhost:8080
+        - --feature-gates=MachinePool=false,ClusterResourceSet=false,ClusterTopology=true
+        command:
+        - /manager
+        image: k8s.gcr.io/cluster-api/cluster-api-controller:v1.1.5
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        - containerPort: 9440
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        resources: {}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccountName: capi-manager
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      volumes:
+      - name: cert
+        secret:
+          secretName: capi-webhook-service-cert
+status: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata: # kpt-merge: capi-system/capi-serving-cert
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-serving-cert
+  namespace: capi-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'cert-manager.io|Certificate|capi-system|capi-serving-cert'
+spec:
+  dnsNames:
+  - capi-webhook-service.capi-system.svc
+  - capi-webhook-service.capi-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: capi-selfsigned-issuer
+  secretName: capi-webhook-service-cert
+  subject:
+    organizations:
+    - k8s-sig-cluster-lifecycle
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata: # kpt-merge: capi-system/capi-selfsigned-issuer
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-selfsigned-issuer
+  namespace: capi-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'cert-manager.io|Issuer|capi-system|capi-selfsigned-issuer'
+spec:
+  selfSigned: {}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata: # kpt-merge: /capi-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    internal.kpt.dev/upstream-identifier: 'admissionregistration.k8s.io|MutatingWebhookConfiguration|default|capi-mutating-webhook-configuration'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinehealthcheck
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinehealthcheck.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinehealthchecks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machineset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-machinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.machinepool.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-cluster-x-k8s-io-v1beta1-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /mutate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata: # kpt-merge: /capi-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: capi-system/capi-serving-cert
+    internal.kpt.dev/upstream-identifier: 'admissionregistration.k8s.io|ValidatingWebhookConfiguration|default|capi-validating-webhook-configuration'
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: cluster-api
+    clusterctl.cluster.x-k8s.io: ""
+  name: capi-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machine.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinedeployment
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinedeployment.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinedeployments
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinehealthcheck
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinehealthcheck.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinehealthchecks
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machineset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machineset.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinesets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-machinepool
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.machinepool.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - machinepools
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-cluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.cluster.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-cluster-x-k8s-io-v1beta1-clusterclass
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterclass.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - clusterclasses
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capi-webhook-service
+      namespace: capi-system
+      path: /validate-addons-cluster-x-k8s-io-v1beta1-clusterresourceset
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.clusterresourceset.addons.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - addons.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterresourcesets
+  sideEffects: None

--- a/nephio-r1-sandbox/cluster-capi/package-context.yaml
+++ b/nephio-r1-sandbox/cluster-capi/package-context.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata: # kpt-merge: /kptfile.kpt.dev
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    internal.kpt.dev/upstream-identifier: '|ConfigMap|default|kptfile.kpt.dev'
+data:
+  name: example

--- a/nephio-r1-sandbox/package-context.yaml
+++ b/nephio-r1-sandbox/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: example

--- a/nephio-r1-sandbox/resource-backend/Kptfile
+++ b/nephio-r1-sandbox/resource-backend/Kptfile
@@ -1,0 +1,22 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: resource-backend
+  annotations:
+    config.kubernetes.io/local-config: "true"
+upstream:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /resource-backend
+    ref: resource-backend/v1
+  updateStrategy: resource-merge
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/nephio-project/nephio-example-packages
+    directory: /resource-backend
+    ref: resource-backend/v1
+    commit: 9f7db663456b7c9c34aa27f05e1034155ada3d93
+info:
+  description: resource-backend controller which hold ipam/vlan

--- a/nephio-r1-sandbox/resource-backend/README.md
+++ b/nephio-r1-sandbox/resource-backend/README.md
@@ -1,0 +1,6 @@
+# resource-backend
+
+## Description
+resource-backend controller which hold ipam/vlan
+
+see [ipam](https://github.com/nokia/k8s-ipam)

--- a/nephio-r1-sandbox/resource-backend/app/Kptfile
+++ b/nephio-r1-sandbox/resource-backend/app/Kptfile
@@ -1,0 +1,9 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+  namespace: resource-backend
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: resource-backend controller which hold ipam/vlan

--- a/nephio-r1-sandbox/resource-backend/app/README.md
+++ b/nephio-r1-sandbox/resource-backend/app/README.md
@@ -1,0 +1,4 @@
+# app
+
+## Description
+resource-backend controller which hold ipam/vlan

--- a/nephio-r1-sandbox/resource-backend/app/controller/clusterrole-controller.yaml
+++ b/nephio-r1-sandbox/resource-backend/app/controller/clusterrole-controller.yaml
@@ -1,0 +1,62 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: # kpt-merge: /resource-backend-controller-controller-role
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: resource-backend
+    app.kubernetes.io/part-of: resource-backend
+    app.kubernetes.io/version: tbd
+  name: resource-backend-controller-controller-role
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRole|default|resource-backend-controller-controller-role'
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - ipam.alloc.nephio.org
+  resources:
+  - ipallocations
+  - ipallocations/status
+  - ipprefixes
+  - ipprefixes/status
+  - networkinstances
+  - networkinstances/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - vlan.alloc.nephio.org
+  resources:
+  - vlanallocations
+  - vlanallocations/status
+  - vlandatabases
+  - vlandatabases/status
+  - vlans
+  - vlans/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete

--- a/nephio-r1-sandbox/resource-backend/app/controller/clusterrolebinding-controller.yaml
+++ b/nephio-r1-sandbox/resource-backend/app/controller/clusterrolebinding-controller.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: # kpt-merge: /resource-backend-controller-controller-role-binding
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: resource-backend
+    app.kubernetes.io/part-of: resource-backend
+    app.kubernetes.io/version: tbd
+  name: resource-backend-controller-controller-role-binding
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|ClusterRoleBinding|default|resource-backend-controller-controller-role-binding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: resource-backend-controller-controller-role
+subjects:
+- kind: ServiceAccount
+  name: resource-backend-controller
+  namespace: backend-system

--- a/nephio-r1-sandbox/resource-backend/app/controller/deployment-controller.yaml
+++ b/nephio-r1-sandbox/resource-backend/app/controller/deployment-controller.yaml
@@ -1,0 +1,120 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: # kpt-merge: backend-system/resource-backend-controller
+  creationTimestamp: null
+  name: resource-backend-controller
+  namespace: backend-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|backend-system|resource-backend-controller'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      fn.kptgen.dev/controller: resource-backend-controller
+      fn.kptgen.dev/grpc: resource-backend-controller
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: tbd
+        app.kubernetes.io/instance: tbd
+        app.kubernetes.io/managed-by: kpt
+        app.kubernetes.io/name: resource-backend
+        app.kubernetes.io/part-of: resource-backend
+        app.kubernetes.io/version: tbd
+        fn.kptgen.dev/controller: resource-backend-controller
+        fn.kptgen.dev/grpc: resource-backend-controller
+      name: resource-backend-controller
+      namespace: backend-system
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+        resources: {}
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: NODE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: RESOURCE_BACKEND
+          value: 127.0.0.1:9999
+        - name: ENABLE_IPALLOCATION
+          value: "true"
+        - name: ENABLE_NETWORKINSTANCE
+          value: "true"
+        - name: ENABLE_IPPREFIX
+          value: "true"
+        #- name: ENABLE_IPSPECIALIZER
+        #  value: "true"
+        - name: ENABLE_VLANALLOCATION
+          value: "true"
+        - name: ENABLE_VLANDATABASE
+          value: "true"
+        - name: ENABLE_vlan
+          value: "true"
+        #- name: ENABLE_VLANSPECIALIZER
+        #  value: "true"
+        image: docker.io/nephio/resource-backend:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: controller
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      serviceAccountName: resource-backend-controller
+status: {}

--- a/nephio-r1-sandbox/resource-backend/app/controller/grpc/service-grpc.yaml
+++ b/nephio-r1-sandbox/resource-backend/app/controller/grpc/service-grpc.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata: # kpt-merge: backend-system/resource-backend-controller-grpc-svc
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: resource-backend
+    app.kubernetes.io/part-of: resource-backend
+    app.kubernetes.io/version: tbd
+    fn.kptgen.dev/grpc: resource-backend-controller
+  name: resource-backend-controller-grpc-svc
+  namespace: backend-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Service|backend-system|resource-backend-controller-grpc-svc'
+spec:
+  ports:
+  - name: grpc
+    port: 9999
+    protocol: TCP
+    targetPort: 9999
+  selector:
+    fn.kptgen.dev/grpc: resource-backend-controller
+status:
+  loadBalancer: {}

--- a/nephio-r1-sandbox/resource-backend/app/controller/role-leader-election.yaml
+++ b/nephio-r1-sandbox/resource-backend/app/controller/role-leader-election.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: # kpt-merge: backend-system/resource-backend-controller-leader-election-role
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: resource-backend
+    app.kubernetes.io/part-of: resource-backend
+    app.kubernetes.io/version: tbd
+  name: resource-backend-controller-leader-election-role
+  namespace: backend-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|Role|backend-system|resource-backend-controller-leader-election-role'
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/nephio-r1-sandbox/resource-backend/app/controller/rolebinding-leader-election.yaml
+++ b/nephio-r1-sandbox/resource-backend/app/controller/rolebinding-leader-election.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: backend-system/resource-backend-controller-leader-election-role-binding
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: resource-backend
+    app.kubernetes.io/part-of: resource-backend
+    app.kubernetes.io/version: tbd
+  name: resource-backend-controller-leader-election-role-binding
+  namespace: backend-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: 'rbac.authorization.k8s.io|RoleBinding|backend-system|resource-backend-controller-leader-election-role-binding'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: resource-backend-controller-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: resource-backend-controller
+  namespace: backend-system

--- a/nephio-r1-sandbox/resource-backend/app/controller/serviceaccount-controller.yaml
+++ b/nephio-r1-sandbox/resource-backend/app/controller/serviceaccount-controller.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata: # kpt-merge: backend-system/resource-backend-controller
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: tbd
+    app.kubernetes.io/instance: tbd
+    app.kubernetes.io/managed-by: kpt
+    app.kubernetes.io/name: resource-backend
+    app.kubernetes.io/part-of: resource-backend
+    app.kubernetes.io/version: tbd
+  name: resource-backend-controller
+  namespace: backend-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|ServiceAccount|backend-system|resource-backend-controller'

--- a/nephio-r1-sandbox/resource-backend/crd/Kptfile
+++ b/nephio-r1-sandbox/resource-backend/crd/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: crd
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: resource-backend crd

--- a/nephio-r1-sandbox/resource-backend/crd/README.md
+++ b/nephio-r1-sandbox/resource-backend/crd/README.md
@@ -1,0 +1,4 @@
+# crd
+
+## Description
+resource-backend crd

--- a/nephio-r1-sandbox/resource-backend/crd/bases/ipam.alloc.nephio.org_ipallocations.yaml
+++ b/nephio-r1-sandbox/resource-backend/crd/bases/ipam.alloc.nephio.org_ipallocations.yaml
@@ -1,0 +1,223 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /ipallocations.ipam.alloc.nephio.org
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|ipallocations.ipam.alloc.nephio.org'
+  creationTimestamp: null
+  name: ipallocations.ipam.alloc.nephio.org
+spec:
+  group: ipam.alloc.nephio.org
+  names:
+    categories:
+    - nephio
+    - alloc
+    kind: IPAllocation
+    listKind: IPAllocationList
+    plural: ipallocations
+    singular: ipallocation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNC
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: STATUS
+      type: string
+    - jsonPath: .spec.networkInstance.name
+      name: NETWORK-INSTANCE
+      type: string
+    - jsonPath: .spec.kind
+      name: KIND
+      type: string
+    - jsonPath: .spec.addressFamily
+      name: AF
+      type: string
+    - jsonPath: .spec.prefixLength
+      name: PREFIXLENGTH
+      type: string
+    - jsonPath: .spec.prefix
+      name: PREFIX-REQ
+      type: string
+    - jsonPath: .status.prefix
+      name: PREFIX-ALLOC
+      type: string
+    - jsonPath: .status.gateway
+      name: GATEWAY
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAllocation is the Schema for the ipallocations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPAllocationSpec defines the desired state of IPAllocation
+            properties:
+              addressFamily:
+                description: AddressFamily defines the address family for the IP allocation
+                enum:
+                - ipv4
+                - ipv6
+                type: string
+              createPrefix:
+                description: CreatePrefix defines if this prefix must be created. Only used for non address prefixes e.g. non /32 ipv4 and non /128 ipv6 prefixes
+                type: boolean
+              index:
+                description: Index defines the index of the IP Allocation, used to get a deterministic IP from a prefix If not present we allocate a random prefix from a prefix
+                format: int32
+                type: integer
+              kind:
+                default: network
+                description: Kind defines the kind of prefix for the IP Allocation - network kind is used for physical, virtual nics on a device - loopback kind is used for loopback interfaces - pool kind is used for pools for dhcp/radius/bng/upf/etc - aggregate kind is used for allocating an aggregate prefix
+                enum:
+                - network
+                - loopback
+                - pool
+                - aggregate
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels as user defined labels
+                type: object
+              networkInstance:
+                description: NetworkInstance defines the networkInstance context for the IP allocation Name and optionally Namespace is used here
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              prefix:
+                description: Prefix defines the prefix for the IP allocation Used for specific prefix allocation or used as a hint for a dynamic prefix allocation in case of restart
+                pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/(([0-9])|([1-2][0-9])|(3[0-2]))|((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))
+                type: string
+              prefixLength:
+                description: PrefixLength defines the prefix length for the IP Allocation If not present we use assume /32 for ipv4 and /128 for ipv6 during allocation
+                type: integer
+              selector:
+                description: Selector defines the selector criterias for the VLAN allocation
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - kind
+            - networkInstance
+            type: object
+          status:
+            description: IPAllocationStatus defines the observed state of IPAllocation
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              expiryTime:
+                description: ExpiryTime defines when the allocation expires
+                type: string
+              gateway:
+                description: Gateway defines the gateway IP for the allocated prefix Gateway is only relevant for prefix kind = network
+                type: string
+              prefix:
+                description: Prefix defines the prefix, allocated by the IPAM backend
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio-r1-sandbox/resource-backend/crd/bases/ipam.alloc.nephio.org_ipprefixes.yaml
+++ b/nephio-r1-sandbox/resource-backend/crd/bases/ipam.alloc.nephio.org_ipprefixes.yaml
@@ -1,0 +1,165 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /ipprefixes.ipam.alloc.nephio.org
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|ipprefixes.ipam.alloc.nephio.org'
+  creationTimestamp: null
+  name: ipprefixes.ipam.alloc.nephio.org
+spec:
+  group: ipam.alloc.nephio.org
+  names:
+    categories:
+    - nephio
+    - alloc
+    kind: IPPrefix
+    listKind: IPPrefixList
+    plural: ipprefixes
+    singular: ipprefix
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNC
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: STATUS
+      type: string
+    - jsonPath: .spec.networkInstance.name
+      name: NETWORK-INSTANCE
+      type: string
+    - jsonPath: .spec.kind
+      name: KIND
+      type: string
+    - jsonPath: .spec.subnetName
+      name: SUBNET
+      type: string
+    - jsonPath: .spec.prefix
+      name: PREFIX-REQ
+      type: string
+    - jsonPath: .status.prefix
+      name: PREFIX-ALLOC
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPPrefix is the Schema for the ipprefixes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IPPrefixSpec defines the desired state of IPPrefix
+            properties:
+              kind:
+                default: network
+                description: Kind defines the kind of prefix for the IP Allocation - network kind is used for physical, virtual nics on a device - loopback kind is used for loopback interfaces - pool kind is used for pools for dhcp/radius/bng/upf/etc - aggregate kind is used for allocating an aggregate prefix
+                enum:
+                - network
+                - loopback
+                - pool
+                - aggregate
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels as user defined labels
+                type: object
+              networkInstance:
+                description: NetworkInstance defines the networkInstance context for the IP prefix Name and optionally Namespace is used here
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              prefix:
+                description: Prefix defines the ip cidr in prefix or address notation.
+                pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/(([0-9])|([1-2][0-9])|(3[0-2]))|((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))
+                type: string
+            required:
+            - kind
+            - networkInstance
+            - prefix
+            type: object
+          status:
+            description: IPPrefixStatus defines the observed state of IPPrefix
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              prefix:
+                description: Prefix defines the prefix, allocated by the IPAM backend
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio-r1-sandbox/resource-backend/crd/bases/ipam.alloc.nephio.org_networkinstances.yaml
+++ b/nephio-r1-sandbox/resource-backend/crd/bases/ipam.alloc.nephio.org_networkinstances.yaml
@@ -1,0 +1,153 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /networkinstances.ipam.alloc.nephio.org
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|networkinstances.ipam.alloc.nephio.org'
+  creationTimestamp: null
+  name: networkinstances.ipam.alloc.nephio.org
+spec:
+  group: ipam.alloc.nephio.org
+  names:
+    categories:
+    - nephio
+    - alloc
+    kind: NetworkInstance
+    listKind: NetworkInstanceList
+    plural: networkinstances
+    singular: networkinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNC
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: STATUS
+      type: string
+    - jsonPath: .metadata.name
+      name: NETWORK-INSTANCE
+      type: string
+    - jsonPath: .spec.prefixes[0].prefix
+      name: PREFIX0
+      type: string
+    - jsonPath: .spec.prefixes[1].prefix
+      name: PREFIX1
+      type: string
+    - jsonPath: .spec.prefixes[2].prefix
+      name: PREFIX2
+      type: string
+    - jsonPath: .spec.prefixes[3].prefix
+      name: PREFIX3
+      type: string
+    - jsonPath: .spec.prefixes[4].prefix
+      name: PREFIX4
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetworkInstance is the Schema for the networkinstances API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkInstanceSpec defines the desired state of NetworkInstance
+            properties:
+              prefixes:
+                description: Prefixes define the aggregate prefixes for the network instance A Network instance needs at least 1 prefix to be defined to become operational
+                items:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels as user defined labels
+                      type: object
+                    prefix:
+                      description: Prefix defines the ip cidr in prefix notation.
+                      pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/(([0-9])|([1-2][0-9])|(3[0-2]))|((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))
+                      type: string
+                  required:
+                  - prefix
+                  type: object
+                type: array
+            required:
+            - prefixes
+            type: object
+          status:
+            description: NetworkInstanceStatus defines the observed state of NetworkInstance
+            properties:
+              allocatedPrefixes:
+                description: Prefixes defines the prefixes, allocated by the IPAM backend
+                items:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels as user defined labels
+                      type: object
+                    prefix:
+                      description: Prefix defines the ip cidr in prefix notation.
+                      pattern: (([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/(([0-9])|([1-2][0-9])|(3[0-2]))|((:|[0-9a-fA-F]{0,4}):)([0-9a-fA-F]{0,4}:){0,5}((([0-9a-fA-F]{0,4}:)?(:|[0-9a-fA-F]{0,4}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(/(([0-9])|([0-9]{2})|(1[0-1][0-9])|(12[0-8])))
+                      type: string
+                  required:
+                  - prefix
+                  type: object
+                type: array
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio-r1-sandbox/resource-backend/crd/bases/vlan.alloc.nephio.org_vlanallocations.yaml
+++ b/nephio-r1-sandbox/resource-backend/crd/bases/vlan.alloc.nephio.org_vlanallocations.yaml
@@ -1,0 +1,184 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /vlanallocations.vlan.alloc.nephio.org
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|vlanallocations.vlan.alloc.nephio.org'
+  creationTimestamp: null
+  name: vlanallocations.vlan.alloc.nephio.org
+spec:
+  group: vlan.alloc.nephio.org
+  names:
+    categories:
+    - nephio
+    - alloc
+    kind: VLANAllocation
+    listKind: VLANAllocationList
+    plural: vlanallocations
+    singular: vlanallocation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNC
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: STATUS
+      type: string
+    - jsonPath: .spec.vlanID
+      name: VLAN-REQ
+      type: string
+    - jsonPath: .status.vlanID
+      name: VLAN-ALLOC
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VLANAllocation is the Schema for the vlan allocations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VLANAllocationSpec defines the desired state of VLANAllocation
+            properties:
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels as user defined labels
+                type: object
+              range:
+                description: VLANRange defines the vlan range for the VLAN allocation
+                type: string
+              selector:
+                description: Selector defines the selector criterias for the VLAN allocation
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              vlanDatabase:
+                description: VLANDatabase defines the vlan database contexts for the VLAN Allocation
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              vlanID:
+                description: VLANID defines the vlan for the VLAN allocation
+                type: integer
+            required:
+            - vlanDatabase
+            type: object
+          status:
+            description: VLANAllocationStatus defines the observed state of VLANAllocation
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              expiryTime:
+                description: ExpiryTime indicated when the allocation expires
+                type: string
+              vlanID:
+                description: VLANID defines the vlan ID, allocated by the VLAN backend
+                type: integer
+              vlanRange:
+                description: VLANRange defines the vlan range, allocated by the VLAN backend
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio-r1-sandbox/resource-backend/crd/bases/vlan.alloc.nephio.org_vlandatabases.yaml
+++ b/nephio-r1-sandbox/resource-backend/crd/bases/vlan.alloc.nephio.org_vlandatabases.yaml
@@ -1,0 +1,113 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /vlandatabases.vlan.alloc.nephio.org
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|vlandatabases.vlan.alloc.nephio.org'
+  creationTimestamp: null
+  name: vlandatabases.vlan.alloc.nephio.org
+spec:
+  group: vlan.alloc.nephio.org
+  names:
+    categories:
+    - nephio
+    - alloc
+    kind: VLANDatabase
+    listKind: VLANDatabaseList
+    plural: vlandatabases
+    singular: vlandatabase
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNC
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: STATUS
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VLANDatabase is the Schema for the vlan database API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VLANDatabaseSpec defines the desired state of VLANDatabase
+            properties:
+              kind:
+                default: esg
+                description: 'Kind defines the kind of vlan database we want to create esg kind is used for ethernet segment groups device kind is used for devices: vlan per device or vlan per interface'
+                enum:
+                - esg
+                - device
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels as user defined labels
+                type: object
+            required:
+            - kind
+            type: object
+          status:
+            description: VLANDatabaseStatus defines the observed state of VLANDatabase
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio-r1-sandbox/resource-backend/crd/bases/vlan.alloc.nephio.org_vlans.yaml
+++ b/nephio-r1-sandbox/resource-backend/crd/bases/vlan.alloc.nephio.org_vlans.yaml
@@ -1,0 +1,150 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: # kpt-merge: /vlans.vlan.alloc.nephio.org
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+    internal.kpt.dev/upstream-identifier: 'apiextensions.k8s.io|CustomResourceDefinition|default|vlans.vlan.alloc.nephio.org'
+  creationTimestamp: null
+  name: vlans.vlan.alloc.nephio.org
+spec:
+  group: vlan.alloc.nephio.org
+  names:
+    categories:
+    - nephio
+    - alloc
+    kind: VLAN
+    listKind: VLANList
+    plural: vlans
+    singular: vlan
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Synced')].status
+      name: SYNC
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: STATUS
+      type: string
+    - jsonPath: .spec.vlanID
+      name: VLAN-REQ
+      type: string
+    - jsonPath: .status.vlanID
+      name: VLAN-ALLOC
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VLAN is the Schema for the vlan API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VLANSpec defines the desired state of VLAN
+            properties:
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels as user defined labels
+                type: object
+              range:
+                description: VLANRange defines a range of vlans
+                type: string
+              vlanDatabase:
+                description: VLANDatabases defines the vlan database contexts for the VLAN Allocation
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              vlanID:
+                description: VLANID defines the VLAN ID
+                type: integer
+            required:
+            - vlanDatabase
+            type: object
+          status:
+            description: VLANStatus defines the observed state of VLAN
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              vlanID:
+                description: VLANID defines the vlan ID, allocated by the VLAN backend
+                type: integer
+              vlanRange:
+                description: VLANRange defines the vlan range, allocated by the VLAN backend
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio-r1-sandbox/resource-backend/namespace.yaml
+++ b/nephio-r1-sandbox/resource-backend/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /backend-system
+  name: backend-system
+  annotations:
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|backend-system'


### PR DESCRIPTION
Two packages to install Nephio R1: one for the base Nephio Management Cluster, and one for additional packages used by the Sandbox Demo environment.

Note that this does not include Gitea in the sandbox package, because it runs in a separate cluster to simulate an external Git provider.