### PR TITLE
Set auto-approval for PV-generated packages

### DIFF
--- a/nephio-workload-cluster/pv-cluster.yaml
+++ b/nephio-workload-cluster/pv-cluster.yaml
@@ -3,6 +3,8 @@ kind: PackageVariant
 metadata:
   name: example-cluster
 spec:
+  annotations:
+    approval.nephio.org/policy: initial
   upstream:
     package: cluster-capi-kind
     repo: nephio-example-packages

--- a/nephio-workload-cluster/pv-configsync.yaml
+++ b/nephio-workload-cluster/pv-configsync.yaml
@@ -3,6 +3,8 @@ kind: PackageVariant
 metadata:
   name: example-configsync
 spec:
+  annotations:
+    approval.nephio.org/policy: initial
   upstream:
     package: configsync
     repo: nephio-example-packages

--- a/nephio-workload-cluster/pv-repo.yaml
+++ b/nephio-workload-cluster/pv-repo.yaml
@@ -3,6 +3,8 @@ kind: PackageVariant
 metadata:
   name: example-repo
 spec:
+  annotations:
+    approval.nephio.org/policy: initial
   upstream:
     package: repository
     repo: nephio-example-packages

--- a/nephio-workload-cluster/pv-rootsync.yaml
+++ b/nephio-workload-cluster/pv-rootsync.yaml
@@ -3,6 +3,8 @@ kind: PackageVariant
 metadata:
   name: example-rootsync
 spec:
+  annotations:
+    approval.nephio.org/policy: initial
   upstream:
     package: rootsync
     repo: nephio-example-packages


### PR DESCRIPTION
This enables auto-approval of the secondary packages created when you Publish a workload cluster package.

With this change, publishing the workload cluster package will be the only step needed to trigger the complete automated cluster creation, registration, and bootstrapping.