### PR TITLE
Fix kindnet approval annotation

### DIFF
--- a/nephio-workload-cluster/pv-kindnet.yaml
+++ b/nephio-workload-cluster/pv-kindnet.yaml
@@ -2,9 +2,9 @@ apiVersion: config.porch.kpt.dev/v1alpha1
 kind: PackageVariant
 metadata:
   name: example-kindnet
-  annotations:     
-    approval.nephio.org/policy: initial
 spec:
+  annotations:
+    approval.nephio.org/policy: initial
   upstream:
     package: kindnet
     repo: nephio-example-packages


### PR DESCRIPTION
Approval annotation belongs on the PackageRevision, not the PackageVariant