### PR TITLE
Add local-path-provisioner.

### DIFF
--- a/local-path-provisioner/Kptfile
+++ b/local-path-provisioner/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: local-path-provisioner
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: Package for local-path-provisioner storage class. 

--- a/local-path-provisioner/Kptfile
+++ b/local-path-provisioner/Kptfile
@@ -6,3 +6,4 @@ metadata:
     config.kubernetes.io/local-config: "true"
 info:
   description: Package for local-path-provisioner storage class. 
+

--- a/local-path-provisioner/README.md
+++ b/local-path-provisioner/README.md
@@ -3,3 +3,4 @@
 ## Description
 
 Package to deploy local-path-prvisioner.
+

--- a/local-path-provisioner/README.md
+++ b/local-path-provisioner/README.md
@@ -1,0 +1,5 @@
+# local-path-provisioner
+
+## Description
+
+Package to deploy local-path-prvisioner.

--- a/local-path-provisioner/clusterrole.yaml
+++ b/local-path-provisioner/clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "nodes", "persistentvolumeclaims", "configmaps" ]
+    verbs: [ "get", "list", "watch" ]
+  - apiGroups: [ "" ]
+    resources: [ "endpoints", "persistentvolumes", "pods" ]
+    verbs: [ "*" ]
+  - apiGroups: [ "" ]
+    resources: [ "events" ]
+    verbs: [ "create", "patch" ]
+  - apiGroups: [ "storage.k8s.io" ]
+    resources: [ "storageclasses" ]
+    verbs: [ "get", "list", "watch" ]

--- a/local-path-provisioner/clusterrole.yaml
+++ b/local-path-provisioner/clusterrole.yaml
@@ -15,3 +15,4 @@ rules:
   - apiGroups: [ "storage.k8s.io" ]
     resources: [ "storageclasses" ]
     verbs: [ "get", "list", "watch" ]
+

--- a/local-path-provisioner/clusterrolebinding.yaml
+++ b/local-path-provisioner/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage

--- a/local-path-provisioner/clusterrolebinding.yaml
+++ b/local-path-provisioner/clusterrolebinding.yaml
@@ -10,3 +10,4 @@ subjects:
   - kind: ServiceAccount
     name: local-path-provisioner-service-account
     namespace: local-path-storage
+

--- a/local-path-provisioner/configmap.yaml
+++ b/local-path-provisioner/configmap.yaml
@@ -1,0 +1,33 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+    {
+            "nodePathMap":[
+            {
+                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                    "paths":["/opt/local-path-provisioner"]
+            }
+            ]
+    }
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      containers:
+      - name: helper-pod
+        image: busybox
+        imagePullPolicy: IfNotPresent

--- a/local-path-provisioner/configmap.yaml
+++ b/local-path-provisioner/configmap.yaml
@@ -31,3 +31,4 @@ data:
       - name: helper-pod
         image: busybox
         imagePullPolicy: IfNotPresent
+

--- a/local-path-provisioner/deployment.yaml
+++ b/local-path-provisioner/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+        - name: local-path-provisioner
+          image: rancher/local-path-provisioner:v0.0.24
+          imagePullPolicy: IfNotPresent
+          command:
+            - local-path-provisioner
+            - --debug
+            - start
+            - --config
+            - /etc/config/config.json
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config/
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      volumes:
+        - name: config-volume
+          configMap:
+            name: local-path-config

--- a/local-path-provisioner/deployment.yaml
+++ b/local-path-provisioner/deployment.yaml
@@ -36,3 +36,4 @@ spec:
         - name: config-volume
           configMap:
             name: local-path-config
+

--- a/local-path-provisioner/namespace.yaml
+++ b/local-path-provisioner/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+  labels:
+    pod-security.kubernetes.io/warn: "privileged"
+    pod-security.kubernetes.io/audit: "privileged"
+    pod-security.kubernetes.io/enforce: "privileged"

--- a/local-path-provisioner/namespace.yaml
+++ b/local-path-provisioner/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
     pod-security.kubernetes.io/warn: "privileged"
     pod-security.kubernetes.io/audit: "privileged"
     pod-security.kubernetes.io/enforce: "privileged"
+

--- a/local-path-provisioner/serviceaccount.yaml
+++ b/local-path-provisioner/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage

--- a/local-path-provisioner/serviceaccount.yaml
+++ b/local-path-provisioner/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: local-path-provisioner-service-account
   namespace: local-path-storage
+

--- a/local-path-provisioner/storageclass.yaml
+++ b/local-path-provisioner/storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete

--- a/local-path-provisioner/storageclass.yaml
+++ b/local-path-provisioner/storageclass.yaml
@@ -7,3 +7,4 @@ metadata:
 provisioner: rancher.io/local-path
 volumeBindingMode: WaitForFirstConsumer
 reclaimPolicy: Delete
+


### PR DESCRIPTION
local-path-provisioner is required to create a storage-class in workload kind clusters. That allows in turn to provision PVC, for instance, required by free5gc mongo-db pods.

Differs from official [local-path-provisoner](https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.24/deploy/local-path-storage.yaml) by:
1) labels attached to the namespace. By default in GCP pods are ns is created with "restricted" pod-security policy which prevents local-provisioner to start helper pods.
```yaml
  labels:
    pod-security.kubernetes.io/warn: "privileged"
    pod-security.kubernetes.io/audit: "privileged"
    pod-security.kubernetes.io/enforce: "privileged"
```
2) annotations attached to the storage-class. Workload kind cluster don't have a storage class by default, hence we need to set local-path-provisioner as default sc.
```yaml
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
```