### PR TITLE
fixes for vlanindexes

### DIFF
--- a/nephio-workload-cluster/pv-vlanindex.yaml
+++ b/nephio-workload-cluster/pv-vlanindex.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.porch.kpt.dev/v1alpha1
 kind: PackageVariant
 metadata:
-  name: example-repo
+  name: example-vlanindex
 spec:
   annotations:
     approval.nephio.org/policy: initial
@@ -11,7 +11,7 @@ spec:
     repo: nephio-example-packages
     revision: v1
   downstream:
-    package: example-repo
+    package: example-vlanindex
     repo: mgmt
   injectors:
   - kind: WorkloadCluster

--- a/vlanindex/vlanindex.yaml
+++ b/vlanindex/vlanindex.yaml
@@ -3,4 +3,4 @@ kind: VLANIndex
 metadata:
   name: example-cluster-name
   namespace: default
-spec:
+spec: {}


### PR DESCRIPTION
there were 2 issues with vlanindex.
1. the pv used repo iso vlanindex
2. the spec object should be a nil object