### PR TITLE
add parameters for specialization in nephio-workload-cluster

### DIFF
--- a/nephio-workload-cluster/workload-cluster.yaml
+++ b/nephio-workload-cluster/workload-cluster.yaml
@@ -6,3 +6,8 @@ spec:
   # Since injection only injects the spec, we need the name here as
   # well as in metadata.
   clusterName: example
+  cnis:
+  - macvlan
+  - ipvlan
+  - sriov
+  masterInterface: eth1


### PR DESCRIPTION
Some additional parameters are required in workload cluster for specialization.
- masterInterface
- cni(s)