### PR TITLE
connect fn and resource injections

### DIFF
--- a/cluster-capi-kind/Kptfile
+++ b/cluster-capi-kind/Kptfile
@@ -10,3 +10,4 @@ pipeline:
   mutators:
   - image: gcr.io/kpt-fn/apply-replacements:v0.1.1
     configPath: apply-replacements.yaml
+  - image: docker.io/nephio/connect-fn:latest

--- a/cluster-capi-kind/link.yaml
+++ b/cluster-capi-kind/link.yaml
@@ -1,0 +1,9 @@
+apiVersion: req.nephio.org/v1alpha1
+kind: Link
+metadata:
+  name: link1
+  labels:
+    nephio.org/nodeId: "0" # can be 0 or 1
+    nephio.org/linkId: "1" # can be 1 or 2
+    nephio.org/interfaceName: "eth1"
+spec:

--- a/cluster-capi-kind/link.yaml
+++ b/cluster-capi-kind/link.yaml
@@ -6,4 +6,6 @@ metadata:
     nephio.org/nodeId: "0" # can be 0 or 1
     nephio.org/linkId: "1" # can be 1 or 2
     nephio.org/interfaceName: "eth1"
+  annotations:
+    config.kubernetes.io/local-config: "true"
 spec:

--- a/cluster-capi-kind/node-leaf1.yaml
+++ b/cluster-capi-kind/node-leaf1.yaml
@@ -1,0 +1,11 @@
+apiVersion: inv.nephio.org/v1alpha1
+kind: Node
+metadata:
+  name: leaf1
+  labels:
+    nephio.org/topology: nephio-sandbox
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    kpt.dev/config-injection: required
+spec:
+  provider: example

--- a/nephio-workload-cluster/pv-cluster.yaml
+++ b/nephio-workload-cluster/pv-cluster.yaml
@@ -16,6 +16,10 @@ spec:
   injectors:
   - kind: WorkloadCluster
     name: example
+  - group: inv.nephio.org
+    version: v1alpha1
+    kind: Node
+    name: leaf1
   pipeline:
     mutators:
     - image: gcr.io/kpt-fn/set-annotations:v0.1.4


### PR DESCRIPTION
this adds to the cluster the connectivity to the network. It specifies a link that represents the connectivity to the network. The nodes are the network devices to which the link is supported.

The connect-fn uses the names to find the ports on the switch/router.

so I use edge01, edge02, edge03, edge04

edge w/o a number is the same as edge01
edge01, uses port 1-4
edge02, uses port 5-8
edge03: uses port 9-12
edge04: uses port 13-16
regional e/o a number is the same as regional01
regional01, uses port 17-20
regional02, uses port 21-24
regional03: uses port 25-28
regional04: uses port 29-32

The connect fn takes care of this. I allow dual homing and single homing. Up to 4 nodes in a cluster and max 4 edge sites and max 4 regional sites. We can do other scenario's but this is what the connect-fn supports right now.

- it uses a node resource: right now I added leaf1 as a fixed name -> other topologies can be added like a dual leaf, etc
the node that is injected is provisioned already during install scripts.

this is what we should add to the install script. deploying the node is still through clab but we will create an operator going fwd. clap installs a bunch of things like CERT, network for mgmt, default config for ssh/gnmi/etc etc. So this is why we should retain it for now. Will replace it with an operator. I give it a fixed ip from the docker kind bridge. we can change it.

besides crab we provision a secret to connect to the device and 2 CR(s) to make the controllers aware about the existence of the node. The node will be used in config injection. The target is used by the controller to configure the config of the switch.

So this should be added to the install.

```yaml
name: nephio

mgmt:
  network: kind

topology:
  kinds:
    srl:
      type: ixrd3
      image: ghcr.io/nokia/srlinux:22.11.2-116
  nodes:
    srl:
      kind: srl
      mgmt-ipv4: 172.18.0.3
```

sudo clab deploy -t clab/srl-nephio.yaml 

```yaml
kubectl create secret generic -n default srl.nokia.com \
  --from-literal username=admin \
  --from-literal password=NokiaSrl1! \
  --type kubernetes.io/basic-auth
```

```yaml
cat <<EOF | kubectl apply -f -
apiVersion: inv.nephio.org/v1alpha1
kind: Target
metadata:
  name: leaf1
  labels:
    nephio.org/node-name: srl
    nephio.org/provider: srl.nokia.com
    nephio.org/topology: nephio-sandbox
spec:
  address: 172.18.0.3:57400
  provider: srl.nokia.com
  secretName: srl.nokia.com
---
apiVersion: inv.nephio.org/v1alpha1
kind: Node
metadata:
  name: leaf1
  labels:
    nephio.org/node-name: srl
    nephio.org/provider: srl.nokia.com
    nephio.org/topology: nephio-sandbox
spec:
  provider: srl.nokia.com
EOF
```

