### PR TITLE
Update CRDs, run token controller in a separate instance

### DIFF
--- a/nephio-controllers/app/controller/deployment-token-controller.yaml
+++ b/nephio-controllers/app/controller/deployment-token-controller.yaml
@@ -3,13 +3,13 @@ kind: Deployment
 metadata:
   annotations: {}
   creationTimestamp: null
-  name: nephio-controller
+  name: token-controller
   namespace: nephio-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      fn.kptgen.dev/controller: nephio-controller
+      fn.kptgen.dev/controller: token-controller
   strategy: {}
   template:
     metadata:
@@ -21,8 +21,8 @@ spec:
         app.kubernetes.io/name: nephio
         app.kubernetes.io/part-of: nephio
         app.kubernetes.io/version: tbd
-        fn.kptgen.dev/controller: nephio-controller
-      name: nephio-controller
+        fn.kptgen.dev/controller: token-controller
+      name: token-controller
       namespace: nephio-system
     spec:
       containers:
@@ -69,22 +69,8 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        - name: GIT_URL
-          value: http://172.18.0.200:3000
-        - name: ENABLE_APPROVAL
+        - name: ENABLE_TOKENS
           value: "true"
-        - name: ENABLE_REPOSITORIES
-          value: "true"
-        - name: ENABLE_BOOTSTRAPSECRETS
-          value: "true"
-        - name: ENABLE_BOOTSTRAPPACKAGES
-          value: "true"
-        - name: ENABLE_GENERICSPECIALIZER
-          value: "true"
-        - name: ENABLE_NETWORKS
-          value: "true"
-        - name: CLIENT_PROXY_ADDRESS
-          value: resource-backend-controller-grpc-svc.backend-system.svc.cluster.local:9999
         image: docker.io/nephio/nephio-operator:latest
         livenessProbe:
           httpGet:

--- a/nephio-controllers/crd/bases/config.nephio.org_networks.yaml
+++ b/nephio-controllers/crd/bases/config.nephio.org_networks.yaml
@@ -1,0 +1,138 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: networks.config.nephio.org
+spec:
+  group: config.nephio.org
+  names:
+    categories:
+    - nephio
+    - config
+    kind: Network
+    listKind: NetworkList
+    plural: networks
+    singular: network
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: REPO_STATUS
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Network is the Schema for the Network API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkSpec defines the desired state of Network Configuration
+            properties:
+              config:
+                description: Config defines the configuration to be applied to a target
+                  device
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              lifecycle:
+                description: Lifecycle determines the lifecycle policies the resource
+                  e.g. delete is orphan or delete will follow
+                properties:
+                  deletionPolicy:
+                    default: delete
+                    description: DeletionPolicy specifies what will happen to the
+                      underlying resource when this resource is deleted - either "delete"
+                      or "orphan" the resource.
+                    enum:
+                    - delete
+                    - orphan
+                    type: string
+                type: object
+            type: object
+          status:
+            description: NetworkStatus defines the observed state of Network
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastAppliedConfig:
+                description: LastAppliedConfig defines the configuration that was
+                  last applied to the target device
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/nephio-controllers/crd/bases/infra.nephio.org_networkconfigs.yaml
+++ b/nephio-controllers/crd/bases/infra.nephio.org_networkconfigs.yaml
@@ -1,0 +1,144 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: networkconfigs.infra.nephio.org
+spec:
+  group: infra.nephio.org
+  names:
+    categories:
+    - nephio
+    - network
+    kind: NetworkConfig
+    listKind: NetworkConfigList
+    plural: networkconfigs
+    singular: networkconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: REPO_STATUS
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetworkConfig is the Schema for the Network API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkConfigSpec defines the desired state of NetworkConfig
+            properties:
+              prefixLengths:
+                description: PrefixLengths define the prefix lengths for ipv4 and
+                  ipv6 configuration elements
+                properties:
+                  ipv4:
+                    description: IPv4 defines the ipv4 prefixlengths
+                    properties:
+                      interfaceExternal:
+                        default: 24
+                        type: integer
+                      interfaceInternal:
+                        default: 31
+                        type: integer
+                      pool:
+                        default: 16
+                        type: integer
+                    type: object
+                  ipv6:
+                    description: IPv6 defines the ipv6 prefixlengths
+                    properties:
+                      interfaceExternal:
+                        default: 64
+                        type: integer
+                      interfaceInternal:
+                        default: 127
+                        type: integer
+                      pool:
+                        default: 48
+                        type: integer
+                    type: object
+                type: object
+            type: object
+          status:
+            description: NetworkStatus defines the observed state of Network
+            properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}


### PR DESCRIPTION
I believe the problem we have been having with the informer sync timeouts is a race condition when we mix controllers that watch package revisions with the token controller.

It seems if Porch cannot read any repo (for example, due to missing secrets), it will fail to sync its informer cache. This is causing issues with the entire controller starting properly. Thus, if the token controller is running in the same instance as anything that watches PackageRevisions, it is not getting properly scheduled to create the secrets.

I tried this on an e2e machine and it seemed to fix it, so I am checking in this but it may need some tweaks after I try it e2e.