### PR TITLE
Set Pod security labels

### DIFF
--- a/ueransim/namespace.yaml
+++ b/ueransim/namespace.yaml
@@ -2,3 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: default
+  labels:
+    pod-security.kubernetes.io/warn: "privileged"
+    pod-security.kubernetes.io/audit: "privileged"
+    pod-security.kubernetes.io/enforce: "privileged"


### PR DESCRIPTION
UERAMSIM pods can not be deployed due to security

```
ubuntu@nephio-r1-e2e:~$ kubectl describe rs ueransim-ue-56fccbc4b6 -n free5gc-ueransim  --context edge01-admin@edge01
Name:           ueransim-ue-56fccbc4b6
Namespace:      free5gc-ueransim
...
Conditions:
  Type             Status  Reason
  ----             ------  ------
  ReplicaFailure   True    FailedCreate
Events:
  Type     Reason        Age                    From                   Message
  ----     ------        ----                   ----                   -------
  Warning  FailedCreate  7m49s                  replicaset-controller  Error creating: pods "ueransim-ue-56fccbc4b6-dsnfl" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "ue" must not include "NET_ADMIN" in securityContext.capabilities.add)
  Warning  FailedCreate  7m49s                  replicaset-controller  Error creating: pods "ueransim-ue-56fccbc4b6-sx5d7" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "ue" must not include "NET_ADMIN" in securityContext.capabilities.add)
  Warning  FailedCreate  7m49s                  replicaset-controller  Error creating: pods "ueransim-ue-56fccbc4b6-2f245" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "ue" must not include "NET_ADMIN" in securityContext.capabilities.add)
  Warning  FailedCreate  7m49s                  replicaset-controller  Error creating: pods "ueransim-ue-56fccbc4b6-c4n26" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "ue" must not include "NET_ADMIN" in securityContext.capabilities.add)
  Warning  FailedCreate  7m49s                  replicaset-controller  Error creating: pods "ueransim-ue-56fccbc4b6-d5q42" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "ue" must not include "NET_ADMIN" in securityContext.capabilities.add)
  Warning  FailedCreate  7m49s                  replicaset-controller  Error creating: pods "ueransim-ue-56fccbc4b6-7tgkf" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "ue" must not include "NET_ADMIN" in securityContext.capabilities.add)
  Warning  FailedCreate  7m49s                  replicaset-controller  Error creating: pods "ueransim-ue-56fccbc4b6-m5b6k" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "ue" must not include "NET_ADMIN" in securityContext.capabilities.add)
  Warning  FailedCreate  7m49s                  replicaset-controller  Error creating: pods "ueransim-ue-56fccbc4b6-z5vkz" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "ue" must not include "NET_ADMIN" in securityContext.capabilities.add)
  Warning  FailedCreate  7m48s                  replicaset-controller  Error creating: pods "ueransim-ue-56fccbc4b6-j4vt9" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "ue" must not include "NET_ADMIN" in securityContext.capabilities.add)
  Warning  FailedCreate  2m21s (x8 over 7m47s)  replicaset-controller  (combined from similar events): Error creating: pods "ueransim-ue-56fccbc4b6-ww227" is forbidden: violates PodSecurity "baseline:latest": non-default capabilities (container "ue" must not include "NET_ADMIN" in securityContext.capabilities.add)
```