### PR TITLE
Remove delay annotation for workload cluster PVs

### DIFF
--- a/nephio-workload-cluster/pv-cluster.yaml
+++ b/nephio-workload-cluster/pv-cluster.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   annotations:
     approval.nephio.org/policy: initial
-    approval.nephio.org/delay: 2m
   upstream:
     package: cluster-capi-kind
     repo: nephio-example-packages

--- a/nephio-workload-cluster/pv-configsync.yaml
+++ b/nephio-workload-cluster/pv-configsync.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   annotations:
     approval.nephio.org/policy: initial
-    approval.nephio.org/delay: 2m
   upstream:
     package: configsync
     repo: nephio-example-packages

--- a/nephio-workload-cluster/pv-kindnet.yaml
+++ b/nephio-workload-cluster/pv-kindnet.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   annotations:
     approval.nephio.org/policy: initial
-    approval.nephio.org/delay: 2m
   upstream:
     package: kindnet
     repo: nephio-example-packages

--- a/nephio-workload-cluster/pv-local-path-provisioner.yaml
+++ b/nephio-workload-cluster/pv-local-path-provisioner.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   annotations:
     approval.nephio.org/policy: initial
-    approval.nephio.org/delay: 2m
   upstream:
     package: local-path-provisioner
     repo: nephio-example-packages

--- a/nephio-workload-cluster/pv-multus.yaml
+++ b/nephio-workload-cluster/pv-multus.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   annotations:
     approval.nephio.org/policy: initial
-    approval.nephio.org/delay: 2m
   upstream:
     package: multus
     repo: nephio-example-packages

--- a/nephio-workload-cluster/pv-repo.yaml
+++ b/nephio-workload-cluster/pv-repo.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   annotations:
     approval.nephio.org/policy: initial
-    approval.nephio.org/delay: 2m
   upstream:
     package: repository
     repo: nephio-example-packages

--- a/nephio-workload-cluster/pv-rootsync.yaml
+++ b/nephio-workload-cluster/pv-rootsync.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   annotations:
     approval.nephio.org/policy: initial
-    approval.nephio.org/delay: 2m
   upstream:
     package: rootsync
     repo: nephio-example-packages

--- a/nephio-workload-cluster/pv-vlanindex.yaml
+++ b/nephio-workload-cluster/pv-vlanindex.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   annotations:
     approval.nephio.org/policy: initial
-    approval.nephio.org/delay: 2m
   upstream:
     package: vlanindex
     repo: nephio-example-packages


### PR DESCRIPTION
These should no longer be needed with the latest version of Porch.

This will result in the need to have a new revision of the nephio-workload-cluster package, so we will also need to update the e2e tests to use that new revision to see the speed up.
