### PR TITLE
Gitea updates

### DIFF
--- a/gitea/README.md
+++ b/gitea/README.md
@@ -6,6 +6,7 @@ Gitea package to deploy a gitea server in a gitea namespace
 
 We assume there is 2 secrets created in the namespace where gitea gets deployed with the following parameters
 
+The password in the below secret are expected to be base64 encoded.
 ```
 cat <<EOF | kubectl apply -f - 
   apiVersion: v1
@@ -20,8 +21,10 @@ cat <<EOF | kubectl apply -f -
   data:
     postgres-password: "...."
     password: "...."
+EOF
 ```
 
+The username and password are expected to be provided as clear text.
 ```
 cat <<EOF | kubectl apply -f - 
   apiVersion: v1
@@ -34,4 +37,73 @@ cat <<EOF | kubectl apply -f -
     username: ...      
     password: ...
 EOF
+```
+
+# OpenShift
+
+When deploying this kpt package on OpenShift, you have to supply a specific SecurityContext because Gitea expect a specific `fsGroup` and `uid` that aren't in the tolerated range of OpenShift. To do so, apply the following manifests, that will create an SCC, a Role and a RoleBinding.
+
+```
+echo "kind: SecurityContextConstraints
+metadata:
+  name: gitea
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gitea-role
+  namespace: gitea
+rules:
+- apiGroups:
+  - security.openshift.io 
+  resourceNames:
+  - gitea
+  resources:
+  - securitycontextconstraints 
+  verbs: 
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gitea-rolebinding
+  namespace: gitea
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  kind: Role
+  name: gitea-role
+  apiGroup: rbac.authorization.k8s.io
+" | kubectl apply -f -
 ```

--- a/gitea/README.md
+++ b/gitea/README.md
@@ -4,41 +4,6 @@
 
 Gitea package to deploy a gitea server in a gitea namespace
 
-We assume there is 2 secrets created in the namespace where gitea gets deployed with the following parameters
-
-The password in the below secret are expected to be base64 encoded.
-```
-cat <<EOF | kubectl apply -f - 
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: gitea-postgresql
-    namespace: gitea
-    labels:
-      app.kubernetes.io/name: postgresql
-      app.kubernetes.io/instance: gitea
-  type: Opaque
-  data:
-    postgres-password: "...."
-    password: "...."
-EOF
-```
-
-The username and password are expected to be provided as clear text.
-```
-cat <<EOF | kubectl apply -f - 
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: git-user-secret
-    namespace: gitea
-  type: kubernetes.io/basic-auth
-  stringData:
-    username: ...      
-    password: ...
-EOF
-```
-
 # OpenShift
 
 When deploying this kpt package on OpenShift, you have to supply a specific SecurityContext because Gitea expect a specific `fsGroup` and `uid` that aren't in the tolerated range of OpenShift. To do so, apply the following manifests, that will create an SCC, a Role and a RoleBinding.

--- a/gitea/namespace.yaml
+++ b/gitea/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitea

--- a/gitea/secret-git-user.yaml
+++ b/gitea/secret-git-user.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: git-user-secret
+  namespace: gitea
+type: kubernetes.io/basic-auth
+stringData:
+  username: gitea
+  password: secret

--- a/gitea/secret-postgresql.yaml
+++ b/gitea/secret-postgresql.yaml
@@ -1,0 +1,12 @@
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: gitea-postgresql
+    namespace: gitea
+    labels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/instance: gitea
+  type: Opaque
+  data:
+    postgres-password: c2VjcmV0
+    password: c2VjcmV0


### PR DESCRIPTION
This PR introduce three changes:

- update documentation to provide steps for deployment on OpenShift (if there is a way to include condition in kpt deployment, I'd rather have these CRs included in the package directly).
- Add gitea postgresql and gitea secret to kpt package: given the configuration is already hardcoded in the configuration, as defined [here](https://github.com/nephio-project/nephio-example-packages/blob/main/gitea/secret-gitea-inline-config.yaml#L21-L22), there is no point in asking the user to create these objects.
- the package is missing the namespace definition, hence when applying it using the following commands
  ```
   kpt pkg get --for-deployment https://github.com/nephio-project/nephio-example-packages.git/gitea@v1.0.1
   kpt fn render gitea/
   kpt live init gitea/
   kpt live apply gitea/ --reconcile-timeout 15m --output=table
  ```
  it fails with 
  ```
  error: task failed (action: "Inventory", name: "inventory-add-0"): namespaces "gitea" not found`
  ```