### PR TITLE
Fix secret-git-user username

### DIFF
--- a/gitea/secret-git-user.yaml
+++ b/gitea/secret-git-user.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: gitea
 type: kubernetes.io/basic-auth
 stringData:
-  username: gitea
+  username: nephio
   password: secret


### PR DESCRIPTION
Apparently, porch/configsync can't connect to gitea services if it's not using `nephio` as username. This needs further investigation.

/cc @johnbelamaric 