### PR TITLE
 Fix resources to work with ConfigSync by removing status

### DIFF
--- a/configsync/config-management-operator.yaml
+++ b/configsync/config-management-operator.yaml
@@ -256,12 +256,6 @@ spec:
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
Continuation of  #80 

ConfigSync fails with

```
[1] KNV1045: Configs with "status" specified are not allowed. To fix, either remove the config or remove the "status" field in the config:  source: /repo/source/bde997d89e9c348a7c3024ef023e7525597e6b02/edge01-configsync/config-management-operator.yaml metadata.name: configmanagements.configmanagement.gke.io group: apiextensions.k8s.io version: v1 kind: CustomResourceDefinition  For more information, see https://g.co/cloud/acm-errors#knv1045
```