### PR TITLE
Update to Porch v0.0.27

### DIFF
--- a/porch-dev/2-function-runner.yaml
+++ b/porch-dev/2-function-runner.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: porch-fn-runner
       containers:
         - name: function-runner
-          image: gcr.io/kpt-dev/porch-function-runner:v0.0.26
+          image: gcr.io/kpt-dev/porch-function-runner:v0.0.27
           imagePullPolicy: IfNotPresent
           command:
             - /server
@@ -44,7 +44,7 @@ spec:
             - --pod-namespace=porch-fn-system
           env:
             - name: WRAPPER_SERVER_IMAGE
-              value: gcr.io/kpt-dev/porch-wrapper-server:v0.0.26
+              value: gcr.io/kpt-dev/porch-wrapper-server:v0.0.27
           ports:
             - containerPort: 9445
           # Add grpc readiness probe to ensure the cache is ready

--- a/porch-dev/2-function-runner.yaml
+++ b/porch-dev/2-function-runner.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: porch-fn-runner
       containers:
         - name: function-runner
-          image: gcr.io/kpt-dev/porch-function-runner:v0.0.24
+          image: gcr.io/kpt-dev/porch-function-runner:v0.0.26
           imagePullPolicy: IfNotPresent
           command:
             - /server
@@ -44,7 +44,7 @@ spec:
             - --pod-namespace=porch-fn-system
           env:
             - name: WRAPPER_SERVER_IMAGE
-              value: gcr.io/kpt-dev/porch-wrapper-server:v0.0.24
+              value: gcr.io/kpt-dev/porch-wrapper-server:v0.0.26
           ports:
             - containerPort: 9445
           # Add grpc readiness probe to ensure the cache is ready

--- a/porch-dev/3-porch-server.yaml
+++ b/porch-dev/3-porch-server.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
         - name: porch-server
           # Update image to the image of your porch apiserver build.
-          image: gcr.io/kpt-dev/porch-server:v0.0.24
+          image: gcr.io/kpt-dev/porch-server:v0.0.26
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -71,7 +71,6 @@ spec:
             - --cache-directory=/cache
             - --cert-dir=/tmp/certs
             - --secure-port=4443
-
 ---
 apiVersion: v1
 kind: Service

--- a/porch-dev/3-porch-server.yaml
+++ b/porch-dev/3-porch-server.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
         - name: porch-server
           # Update image to the image of your porch apiserver build.
-          image: gcr.io/kpt-dev/porch-server:v0.0.26
+          image: gcr.io/kpt-dev/porch-server:v0.0.27
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/porch-dev/9-controllers.yaml
+++ b/porch-dev/9-controllers.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
       - name: porch-controllers
         # Update to the image of your porch-controllers build.
-        image: gcr.io/kpt-dev/porch-controllers:v0.0.26
+        image: gcr.io/kpt-dev/porch-controllers:v0.0.27
         # Note: only the existence of the variable matters for enabling the reconciler
         # So, be sure to remove the var not just change the value to false
         env:

--- a/porch-dev/9-controllers.yaml
+++ b/porch-dev/9-controllers.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
       - name: porch-controllers
         # Update to the image of your porch-controllers build.
-        image: gcr.io/kpt-dev/porch-controllers:v0.0.24
+        image: gcr.io/kpt-dev/porch-controllers:v0.0.26
         # Note: only the existence of the variable matters for enabling the reconciler
         # So, be sure to remove the var not just change the value to false
         env:


### PR DESCRIPTION
Porch v0.0.26 fixes a number of issues, including periodic crashes due to OOMKill.

The new version dramatically reduces the number of watch events sent. Previously, they were sent every minute or so, regardless of whether there was a change in a PackageRevision. It now only sends them when there is an actual change. If you have controller code that is watching PackageRevisions, and it does not use `RequeueAfter` in the reconciler return value when there is an error, this could cause *functional* problems for you.

If you look at the [specific PR](https://github.com/kptdev/kpt/pull/4050), you will see I needed to update the PackageVariant controller for this reason. Basically, if you need to "check later" due to an error that may be intermittent, then you need your controller to use `Requeue` or `RequeueAfter`.

If the error is something that will require a new PackageRevision ResourceVersion (ie, a new commit), then you do not need to requeue, because you will be notified of that change.

But if it's external to the package revision (say, a intermittent network issue, a missing RBAC role, etc.), that may be resolved *without* a new commit, then you need to be sure you tell the controller to requeue after some amount of time, to be sure you reconcile that resource version of the package revision again.

Fixes https://github.com/nephio-project/porch/issues/580