### PR TITLE
Fix Multus CNI init Container

### DIFF
--- a/multus/multus-daemonset-thick.yml
+++ b/multus/multus-daemonset-thick.yml
@@ -152,7 +152,7 @@ spec:
       serviceAccountName: multus
       containers:
         - name: kube-multus
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.0.2
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.0.2-thick
           command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
           resources:
             requests:
@@ -185,7 +185,7 @@ spec:
               mountPropagation: HostToContainer
       initContainers:
         - name: install-multus-binary
-          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.0.2
+          image: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.0.2-thick
           command:
             - "cp"
             - "/usr/src/multus-cni/bin/multus-shim"


### PR DESCRIPTION
The Multus init container requires `cp` command for copying the `multus-shim` binary. This change uses the latest thick stable version.