### PR TITLE
Add RBAC for OpenShift clusters to bootstrap controller role

### DIFF
--- a/nephio-controllers/app/controller/clusterrole-bootstrap.yaml
+++ b/nephio-controllers/app/controller/clusterrole-bootstrap.yaml
@@ -13,6 +13,14 @@ metadata:
   name: nephio-controller-bootstrap-role
 rules:
 - apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - managedclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusters


### PR DESCRIPTION
This is required once the following change in Nephio is approved
https://github.com/nephio-project/nephio/pull/421
