### PR TITLE
aligned with pr 455

### DIFF
--- a/repository/set-values.yaml
+++ b/repository/set-values.yaml
@@ -30,7 +30,7 @@ source: |-
            r["metadata"]["annotations"]["nephio.org/staging"] = "true"
       if krmfn.match_gvk(r, "infra.nephio.org/v1alpha1", "Token"):
         r["metadata"]["name"] = clusterName + "-access-token-porch"
-        if "annotations" in r["metadata"] and "nephio.org/app" in r["metadata"]["annotations"] and "configsync" in r["metadata"]["annotations"]["nephio.org/app"]:
+        if "annotations" in r["metadata"] and "nephio.org/gitops" in r["metadata"]["annotations"] and "configsync" in r["metadata"]["annotations"]["nephio.org/gitops"]:
           r["metadata"]["name"] = clusterName + "-access-token-configsync"
           if clusterName == "mgmt" or clusterName == "mgmt-staging":
             r["metadata"]["namespace"] = "config-management-system"

--- a/repository/token-configsync.yaml
+++ b/repository/token-configsync.yaml
@@ -4,5 +4,7 @@ metadata:
   name: example-site-name-access-token-configsync
   namespace: default
   annotations:
-    nephio.org/app: configsync
+    nephio.org/gitops: configsync
+    nephio.org/app: tobeinstalledonremotecluster
+    nephio.org/remote-namespace: config-management-system
 spec: {}


### PR DESCRIPTION
this is an update to the package to make the bootstrap secret controller independent of configsync.
it has to be aligned with https://github.com/nephio-project/nephio/pull/455